### PR TITLE
Add option for extra Fontawesome icon from version 5.14.0

### DIFF
--- a/src/components/ood/oodIconCard.js
+++ b/src/components/ood/oodIconCard.js
@@ -10,15 +10,12 @@ const OodIconCard = (props) => (
     }>
       <a href={props.blok.link} rel="nofollow noopener" className={`tile-card__link su-bg-${props.blok.backgroundColor}`}>
         <div className="ood-icon-card__media">
-          {props.blok.icon.icon && (
-            <span aria-hidden="true"
-                  className={`ood-icon-card__icon
-                  ${props.blok.icon.type}
-                  ${props.blok.icon.icon}
-                  ${props.blok.iconStyle ? props.blok.iconStyle : ""}
-                   ${(props.blok.backgroundColor !== "white" && props.blok.backgroundColor !== "fog-light") ? "su-text-white" : "su-text-digital-red"}
-             `} />
-          )}
+          <span aria-hidden="true"
+                className={`ood-icon-card__icon
+                ${props.blok.iconStyle ? props.blok.iconStyle : props.blok.icon.type}
+                ${props.blok.extraIcon ? props.blok.extraIcon : props.blok.icon.icon}
+                ${(props.blok.backgroundColor !== "white" && props.blok.backgroundColor !== "fog-light") ? "su-text-white" : "su-text-digital-red"}
+           `} />
         </div>
         <section className="su-card__contents ood-icon-card__contents">
           <h2 className="ood-icon-card__headline">{props.blok.headline}</h2>


### PR DESCRIPTION
# READY FOR REVIEW
# Summary
- The Area of Support Cards need extra fontawesome icon that aren't available from the Storyblok Fontawesome selector plugin (using 5.9.0). Find a way to make those newer icons available.

# Needed By (Date)
- When does this need to be merged by?

# Urgency
- How critical is this PR?

# Steps to Test

1. Do this
1. Then this
2. Then this

# Affected Projects or Products
- Does this PR impact any particular projects, products, or modules?

# Associated Issues and/or People
- JIRA ticket
- Other PRs
- Any other contextual information that might be helpful (e.g., description of a bug that this PR fixes, new functionality that it adds, etc.)
- Anyone who should be notified? (`@mention` them here)

# See Also
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)