### PR TITLE
Make HeaderNoImage component reusable

### DIFF
--- a/src/components/page-types/oodInteriorPage.js
+++ b/src/components/page-types/oodInteriorPage.js
@@ -1,9 +1,9 @@
 import React from 'react'
-import Link from 'gatsby-link'
 import SbEditable from 'storyblok-react'
 import RichTextField from '../richTextField'
 import Components from "../components"
-import { Helmet } from 'react-helmet';
+import HeaderNoImage from '../partials/headerNoImage'
+import { Helmet } from 'react-helmet'
 
 const HeaderWithImage = (props) => (
   <SbEditable content={props.blok}>
@@ -22,28 +22,6 @@ const HeaderWithImage = (props) => (
         <div className={`centered-container flex-container`}>
           {props.blok.intro && (
             <div className="su-intro-text ood-interior-page__intro flex-xl-8-of-12">
-              <RichTextField data={props.blok.intro}/>
-            </div>
-          )}
-        </div>
-      </div>
-    </header>
-  </SbEditable>
-)
-
-const HeaderNoImage = (props) => (
-  <SbEditable content={props.blok}>
-    <header className={`ood-interior-page__header ood-interior-page__header`}>
-      <div className={`ood-interior-page__header-title-wrapper su-pt-7 su-bg-${props.blok.headerBackgroundColor}`}>
-        <div className={`centered-container`}>
-          <h1 className="ood-interior-page__title flex-xl-10-of-12 su-serif su-text-white su-text-align-center">{props.blok.title}</h1>
-        </div>
-      </div>
-      <div className={`centered-container flex-container ood-interior-page__header-content`}>
-        <div className={`ood-interior-page__header-content-wrapper flex-12-of-12
-                       su-bg-white su-text-align-center`}>
-          {props.blok.intro && (
-            <div className="su-intro-text ood-interior-page__intro flex-xl-10-of-12">
               <RichTextField data={props.blok.intro}/>
             </div>
           )}

--- a/src/components/page-types/oodSupportPage.js
+++ b/src/components/page-types/oodSupportPage.js
@@ -1,9 +1,9 @@
 import React from 'react'
-import Link from 'gatsby-link'
 import SbEditable from 'storyblok-react'
 import RichTextField from '../richTextField'
 import Components from "../components"
-import { Helmet } from 'react-helmet';
+import HeaderNoImage from '../partials/headerNoImage'
+import { Helmet } from 'react-helmet'
 
 const OodSupportPage = (props) => {
 
@@ -15,19 +15,11 @@ const OodSupportPage = (props) => {
           key: blok._uid,
           blok: blok
         }))}
-        <main id="main-content">
-          <article className={`ood-support-page su-bg-fog-light`}>
-            <header className={`ood-support-page__header su-pt-7 su-bg-${props.blok.headerBackgroundColor}`}>
-              <div className={`centered-container flex-container ood-support-page__header-content`}>
-                <h1 className="ood-support-page__title flex-12-of-12 su-serif su-text-white su-text-align-center">{props.blok.title}</h1>
-                <div className={`ood-support-page__header-content-wrapper flex-12-of-12
-                     su-bg-white su-text-align-center`}>
-                  {props.blok.intro && (
-                    <p className="su-intro-text ood-support-page__intro">{props.blok.intro}</p>
-                  )}
-                </div>
-              </div>
-            </header>
+        <main id="main-content"
+              className="ood-interior-page--no-image ood-support-page"
+        >
+          <article className={`su-bg-fog-light`}>
+            <HeaderNoImage {...props}/>
             <section className="ood-support-page__body">
               <header className="centered-container ood-support-page__body-header su-text-align-center">
                 <h2 className="ood-support-page__body-header-title su-serif">{props.blok.cardSectionTitle}</h2>

--- a/src/components/partials/headerNoImage.js
+++ b/src/components/partials/headerNoImage.js
@@ -1,0 +1,26 @@
+import React from "react";
+import SbEditable from "storyblok-react";
+import RichTextField from "../richTextField";
+
+const HeaderNoImage = (props) => (
+  <SbEditable content={props.blok}>
+    <header className={`ood-interior-page__header ood-interior-page__header`}>
+      <div className={`ood-interior-page__header-title-wrapper su-pt-7 su-bg-${props.blok.headerBackgroundColor}`}>
+        <div className={`centered-container`}>
+          <h1 className="ood-interior-page__title flex-xl-10-of-12 su-serif su-text-white su-text-align-center">{props.blok.title}</h1>
+        </div>
+      </div>
+      <div className={`centered-container flex-container ood-interior-page__header-content`}>
+        <div className={`ood-interior-page__header-content-wrapper flex-12-of-12 su-bg-white su-text-align-center`}>
+          {props.blok.intro && (
+            <div className="su-intro-text ood-interior-page__intro flex-xl-10-of-12">
+              <RichTextField data={props.blok.intro}/>
+            </div>
+          )}
+        </div>
+      </div>
+    </header>
+  </SbEditable>
+)
+
+export default HeaderNoImage


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- Create component HeaderNoImage and use it on both Interior Page and Areas to Support page types

# Needed By (Date)
- When does this need to be merged by?

# Urgency
- How critical is this PR?

# Steps to Test

1. Do this
1. Then this
2. Then this

# Affected Projects or Products
- Does this PR impact any particular projects, products, or modules?

# Associated Issues and/or People
- JIRA ticket
- Other PRs
- Any other contextual information that might be helpful (e.g., description of a bug that this PR fixes, new functionality that it adds, etc.)
- Anyone who should be notified? (`@mention` them here)

# See Also
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)…e and Areas to Support page types