### PR TITLE
ADAPT-725 Improve lockup and all 3 navItem Link component logic

### DIFF
--- a/src/components/identity/lockup.js
+++ b/src/components/identity/lockup.js
@@ -1,21 +1,38 @@
 import React from 'react'
+import Link from "gatsby-link"
 import SbEditable from 'storyblok-react'
 
-const Lockup = (props) => (
-  <SbEditable content={props.blok}>
-    <div class="su-lockup su-lockup--option-n">
-      <a href={props.blok.logoLink}>
-        <div class="su-lockup__cell1">
-          <div class="su-lockup__wordmark-wrapper">
-            <span class="su-lockup__wordmark">Stanford</span>
-          </div>
+const Lockup = (props) => {
+
+  const LockupContent = (props) => (
+    <SbEditable content={props.blok}>
+      <div className="su-lockup__cell1">
+        <div className="su-lockup__wordmark-wrapper">
+          <span className="su-lockup__wordmark">Stanford</span>
         </div>
-        <div class="su-lockup__cell2">
-          <span class="su-lockup__line1">{props.blok.lineOne}</span>
-        </div>
-      </a>
-    </div>
-  </SbEditable>
-)
+      </div>
+      <div className="su-lockup__cell2">
+        <span className="su-lockup__line1">{props.blok.lineOne}</span>
+      </div>
+    </SbEditable>
+  );
+
+  return (
+    <SbEditable content={props.blok}>
+      <div className="su-lockup su-lockup--option-n">
+        {props.blok.link.linktype === "story" &&
+          <Link to={props.blok.link.cached_url === 'home' ? "/" : `/${props.blok.link.cached_url}/`}>
+            <LockupContent {...props}/>
+          </Link>
+        }
+        {props.blok.link.linktype === "url" &&
+          <a href={props.blok.link.url}>
+            <LockupContent {...props}/>
+          </a>
+        }
+      </div>
+    </SbEditable>
+  )
+};
 
 export default Lockup

--- a/src/components/navigation/contentNavItem.js
+++ b/src/components/navigation/contentNavItem.js
@@ -6,7 +6,7 @@ const ContentNavItem = (props) => (
   <SbEditable content={props.blok}>
     <li className="su-secondary-nav__item ood-content-nav__item">
       {props.blok.link.linktype === "story" &&
-        <Link to={props.blok.link === 'home' ? "/" : `/${props.blok.link.cached_url}/`}
+        <Link to={props.blok.link.cached_url === "home" ? "/" : `/${props.blok.link.cached_url}${props.blok.link.cached_url.endsWith("/") ? "/" : ""}`}
               activeClassName="ood-content-nav__link--active"
               className="su-secondary-nav__link ood-content-nav__link">
           {props.blok.linkText}

--- a/src/components/navigation/navItem.js
+++ b/src/components/navigation/navItem.js
@@ -6,11 +6,16 @@ const NavItem = (props) => (
   <SbEditable content={props.blok}>
     <li>
       {props.blok.link.linktype === "story" &&
-      <Link to={props.blok.link === 'home' ? "/" : `/${props.blok.link.cached_url}/`} activeClassName="active">{props.blok.linkTextLabel}
-      </Link>}
+        <Link to={props.blok.link.cached_url === "home" ? "/" : `/${props.blok.link.cached_url}${props.blok.link.cached_url.endsWith("/") ? "" : "/"}`}
+              activeClassName="active">
+          {props.blok.linkTextLabel}
+        </Link>
+      }
       {props.blok.link.linktype === "url" &&
-      <a href={props.blok.link.url} className="su-link--external">{props.blok.linkTextLabel}
-      </a>}
+        <a href={props.blok.link.url} className="su-link--external">
+          {props.blok.linkTextLabel}
+        </a>
+      }
     </li>
   </SbEditable>
 )

--- a/src/components/navigation/oodMegaMenuNavItem.js
+++ b/src/components/navigation/oodMegaMenuNavItem.js
@@ -6,7 +6,7 @@ const OodMegaMenuNavItem = (props) => (
   <SbEditable content={props.blok}>
     <li className="ood-mega-nav__item">
       {props.blok.link.linktype === "story" &&
-        <Link to={props.blok.link === 'home' ? "/" : `/${props.blok.link.cached_url}/`}
+        <Link to={props.blok.link.cached_url === "home" ? "/" : `/${props.blok.link.cached_url}${props.blok.link.cached_url.endsWith("/") ? "" : "/"}`}
               className="ood-mega-nav__link" activeClassName="ood-mega-nav__link--active">
           {props.blok.linkText}
         </Link>


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- Improve logic on navItem (generic, for content menu and for mega menu) Link component so the URL renders as "/" when the slug is "home". It adds a "/" at the end for internal links if it's not a top level page (for Gatsby active link to work, it needs this trailing /), and if a page is a directory root page (slug ends in "/"), then no need to add this "/" at the end.
- Improve the lockup component to use the Link component.

# Needed By (Date)
- When does this need to be merged by?

# Urgency
- How critical is this PR?

# Steps to Test

1. Do this
1. Then this
2. Then this

# Affected Projects or Products
- Does this PR impact any particular projects, products, or modules?

# Associated Issues and/or People
- JIRA ticket
- Other PRs
- Any other contextual information that might be helpful (e.g., description of a bug that this PR fixes, new functionality that it adds, etc.)
- Anyone who should be notified? (`@mention` them here)

# See Also
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)