### PR TITLE
ADAPT-1134 Close mega menu dropdown when Escape key is pressed

### DIFF
--- a/src/components/navigation/megaMenu/oodMegaMenuSection.js
+++ b/src/components/navigation/megaMenu/oodMegaMenuSection.js
@@ -3,6 +3,7 @@ import SbEditable from "storyblok-react"
 import CreateBloks from "../../../utilities/createBloks"
 import UseOnClickOutside from "../../../hooks/useOnClickOutside"
 import CenteredContainer from "../../partials/centeredContainer"
+import UseEscape from "../../../hooks/useEscape"
 
 const OodMegaMenuSection = (props) => {
   const [sectionOpened, setSectionOpened] = useState(false);
@@ -12,6 +13,7 @@ const OodMegaMenuSection = (props) => {
     setSectionOpened(!sectionOpened);
   }
 
+  UseEscape(() => setSectionOpened(false));
   UseOnClickOutside(ref, () => setSectionOpened(false));
 
   return (

--- a/src/hooks/useEscape.js
+++ b/src/hooks/useEscape.js
@@ -1,0 +1,17 @@
+import React, { useEffect } from 'react';
+
+const UseEscape = (onEscape) => {
+  useEffect(() => {
+    const handleEsc = (event) => {
+      if (event.keyCode === 27)
+        onEscape();
+    };
+    window.addEventListener('keydown', handleEsc);
+
+    return () => {
+      window.removeEventListener('keydown', handleEsc);
+    };
+  }, []);
+}
+
+export default UseEscape


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- Enable the escape key to close the mega menu drop down

# Review By (Date)
- When does this need to be reviewed by?

# Criticality
- How critical is this PR on a 1-10 scale? Also see [Severity Assessment](https://stanfordits.atlassian.net/browse/D8CORE-1705).
- E.g., it affects one site, or every site and product?

# Review Tasks

## Setup tasks and/or behavior to test

1. go to https://deploy-preview-104--adapt-giving.netlify.app/
2. Open up one of the mega menu drop downs
3. Hit escape key and see that it closes the drop down, and that it sets the trigger button aria-expanded back to false, and the dropdown aria-hidden back to true after the drop down is close.

## Front End Validation
- [ ] Is the markup using the appropriate semantic tags and passes HTML validation?
- [ ] Cross-browser testing has been performed?
- [ ] Automated accessibility scans performed?
- [ ] Manual accessibility tests performed?
- [ ] Design is approved by @ user?

## Backend / Functional Validation
### Code
- [ ] Are the naming conventions following our standards?
- [ ] Does the code have sufficient inline comments?
- [ ] Is there anything in this code that would be hidden or hard to discover through the UI?
- [ ] Are there any [code smells](https://blog.codinghorror.com/code-smells/)?
- [ ] Are tests provided? eg (unit, behat, or codeception)

### Code security
- [ ] Are all [forms properly sanitized](https://www.drupal.org/docs/8/security/drupal-8-sanitizing-output)?
- [ ] Any obvious [security flaws or new areas for attack](https://www.drupal.org/docs/8/security)?

## General
- [ ] Is there anything included in this PR that is not related to the problem it is trying to solve?
- [ ] Is the approach to the problem appropriate?

# Affected Projects or Products
- Does this PR impact any particular projects, products, or modules?

# Associated Issues and/or People
- JIRA ticket(s)
- Other PRs
- Any other contextual information that might be helpful (e.g., description of a bug that this PR fixes, new functionality that it adds, etc.)
- Anyone who should be notified? (`@mention` them here)

# Resources
- [AMP Tool](https://stanford.levelaccess.net/index.php)
- [Accessibility Manual Test Script](https://docs.google.com/document/d/1ZXJ9RIUNXsS674ow9j3qJ2g1OAkCjmqMXl0Gs8XHEPQ/edit?usp=sharing)
- [HTML Validator](https://validator.w3.org/)
- [Browserstack](https://live.browserstack.com/dashboard) and link to [Browserstack Credentials](https://asconfluence.stanford.edu/confluence/display/SWS/External+Account+Credentials)
