### PR TITLE
ADAPT-000: Sitemap path updates.

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -25,7 +25,9 @@
 # https://www.npmjs.com/package/netlify-plugin-submit-sitemap
 # ###############################################################################
 [[plugins]]
-  package = "netlify-plugin-submit-sitemap"
-
+package = "netlify-plugin-submit-sitemap"
+  [plugins.inputs]
+    # Path to the sitemap URL (optional, default = /sitemap.xml)
+    sitemapPath = "/sitemap/sitemap-index.xml"
 # REDIRECTS are located in static/_redirects
 # ###############################################################################


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- Corrects the path for sitemap submission. Gatsby sitemaps are generated in a directory and not at `/sitemap.xml`

# Review By (Date)
- Whenever

# Criticality
- 7.5/10

# Review Tasks

## Setup tasks and/or behavior to test

1. Review build logs.
2. Ensure no sitemap is generated in this build
3. Validate path https://deploy-preview-214--adapt-giving.netlify.app/sitemap/sitemap-index.xml exists
4. Validate path https://deploy-preview-214--adapt-giving.netlify.app/sitemap/sitemap-0.xml exists
