### PR TITLE
ADAPT-3202 | @mattanglin | campaign header homelink

### DIFF
--- a/src/components/identity/oodCampaignHeader.js
+++ b/src/components/identity/oodCampaignHeader.js
@@ -9,20 +9,21 @@ const OodCampaignHeader = (props) => {
       <div className={`campaign-page__header-inner ${props.blok.headerColor}`}>
         <div className="flex-container centered-container su-align-items-baseline su-justify-content">
           <CreateBloks blokSection={props.blok.lockup} />
+          {!props.blok.hideHomeLink && (
+            <SbLink link={props.blok.homeLink} classes={`campaign-page__header-icon ${props.blok.headerColor}`}>
+              <svg xmlns="http://www.w3.org/2000/svg" className="home-icon" fill="none" viewBox="0 0 24 24"
+                  stroke="currentColor">
+                <path
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  strokeWidth={2}
+                  d="M3 12l2-2m0 0l7-7 7 7M5 10v10a1 1 0 001 1h3m10-11l2 2m-2-2v10a1 1 0 01-1 1h-3m-6 0a1 1 0 001-1v-4a1 1 0 011-1h2a1 1 0 011 1v4a1 1 0 001 1m-6 0h6"
+                />
+              </svg>
 
-          <SbLink link={props.blok.homeLink} classes={`campaign-page__header-icon ${props.blok.headerColor}`}>
-            <svg xmlns="http://www.w3.org/2000/svg" className="home-icon" fill="none" viewBox="0 0 24 24"
-                 stroke="currentColor">
-              <path
-                strokeLinecap="round"
-                strokeLinejoin="round"
-                strokeWidth={2}
-                d="M3 12l2-2m0 0l7-7 7 7M5 10v10a1 1 0 001 1h3m10-11l2 2m-2-2v10a1 1 0 01-1 1h-3m-6 0a1 1 0 001-1v-4a1 1 0 011-1h2a1 1 0 011 1v4a1 1 0 001 1m-6 0h6"
-              />
-            </svg>
-
-            Home
-          </SbLink>
+              Home
+            </SbLink>
+          )}
         </div>
       </div>
     </SbEditable>


### PR DESCRIPTION
# Ready for Review
- (Edit the above to reflect status)

# Summary
Adds visibility toggle for campaign header home link (top right corner)
https://stanfordits.atlassian.net/browse/ADAPT-3202

# Review By (Date)
- August 5th, 2021 @ 4:00pm (PDT) (For sync w/ OOD)

# Criticality
- 1

# Review Tasks

1. Check out this branch
2. Setup env with Storyblok key for  DEV - OOD Giving
3. Enable "Hide Home Link" field for the [test story in dev](https://app.storyblok.com/#!/me/spaces/122401/stories/0/0/65417732/blok/d5ff285c-3243-431a-8e18-1c584c621863?s=1)
4. Run gatsby locally and navigate to http://localhost:8000/campaign-page-2
5. verfiy that home link is hidden
6. Uncheck ("Disable") "Hide Home Link" field
7. Refresh GraphQL cache
8. Verify that home link is visible

