### PR TITLE
ADAPT-3203: Campaign hero serif variant

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
       "dependencies": {
         "@fortawesome/fontawesome-free": "^5.15.1",
         "algoliasearch": "^4.8.3",
+        "classnames": "^2.3.1",
         "decanter": "^6.2.3",
         "gatsby": "^3.5.0",
         "gatsby-plugin-algolia": "^0.20.0",
@@ -63031,6 +63032,7 @@
           "integrity": "sha512-5vwpq6kbvwkQwKqAoOU3L72GZ3Ta8RRrewKj9OJRolx28KLJJ8Dg9Rf7obRwt5jQA9bkYd8gqzMTrI7H3xLfaw==",
           "dev": true,
           "requires": {
+            "@oclif/config": "^1.15.1",
             "@oclif/errors": "^1.3.3",
             "@oclif/parser": "^3.8.3",
             "@oclif/plugin-help": "^3",

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
   "dependencies": {
     "@fortawesome/fontawesome-free": "^5.15.1",
     "algoliasearch": "^4.8.3",
+    "classnames": "^2.3.1",
     "decanter": "^6.2.3",
     "gatsby": "^3.5.0",
     "gatsby-plugin-algolia": "^0.20.0",

--- a/src/components/partials/campaignHero.js
+++ b/src/components/partials/campaignHero.js
@@ -1,5 +1,6 @@
 import React from "react"
 import SbEditable from "storyblok-react"
+import cx from "classnames";
 import CreateBloks from "../../utilities/createBloks"
 import Heading from "./heading"
 import FullWidthImage from "../media/fullWidthImage";
@@ -51,7 +52,7 @@ const CampaignHero = (props) => {
               <Heading
                 level={"h1"}
                 weight={`${isFullWidthImage  ? 'regular' : 'semibold'}`}
-                serif={blok.heroStyle === 'fullwidth-image'}
+                serif={blok.heroStyle === 'fullwidth-image' || blok.heroTitleFontSerif}
                 classes={`campaign-page__title ${blok.heroTitleType}`}
               >
                 {blok.title}
@@ -60,7 +61,7 @@ const CampaignHero = (props) => {
                 <div className={`campaign-page__hero-bar su-bg-${blok.barBgColor} ${blok.barAlignment}`} />
               }
               {blok.intro &&
-                <p className='campaign-page__hero-intro su-mb-none'>
+                <p className={cx('campaign-page__hero-intro su-mb-none', { 'su-serif': blok.heroIntroFontSerif })}>
                   {blok.intro}
                 </p>
               }


### PR DESCRIPTION
# Ready for Review

# Summary
Adds Serif font options for Hero title and intro texts to campaign pages
https://stanfordits.atlassian.net/browse/ADAPT-3203

# Review By (Date)
- August 5th, 2021 @ 4:00pm (PDT) (For sync w/ OOD)

# Criticality
- 1

# Review Tasks

1. Check out this branch
2. Setup env with Storyblok key for  DEV - OOD Giving
3. Enable "Hero Title font serifs" field for the [test story in dev](https://app.storyblok.com/#!/me/spaces/122401/stories/0/0/65417730/blok/85dafcc2-9295-40ff-97fb-487d887cd365?s=1)
4. Run gatsby locally and navigate to http://localhost:8000/campaign-page
5. verfiy that hero title text renders with serif font
6. Uncheck ("Disable") "Hero Title font serifs" field
7. Refresh GraphQL cache
8. Verify that hero title text renders without serifs

![image](https://user-images.githubusercontent.com/1952337/129984965-2c605001-3da7-4f75-909a-93ebaf75f7cf.png)

