### PR TITLE
ADAPT-5488 | Add IDEAL category to areas to support page

### DIFF
--- a/src/components/page-types/oodSupportPage.js
+++ b/src/components/page-types/oodSupportPage.js
@@ -105,11 +105,11 @@ const OodSupportPage = (props) => {
                 <label htmlFor="culture">Culture, Ethics, + Service</label>
                 <input
                   type="radio"
-                  id="ideal"
+                  id="dei"
                   name="areas-to-support"
                   onClick={updateHash}
                 />
-                <label htmlFor="ideal">IDEAL</label>
+                <label htmlFor="dei">Diversity, Equity, + Inclusion</label>
                 <input
                   type="radio"
                   id="law"
@@ -159,7 +159,7 @@ const OodSupportPage = (props) => {
                   <CreateBloks blokSection={props.blok.athletics} />
                   <CreateBloks blokSection={props.blok.business} />
                   <CreateBloks blokSection={props.blok.culture} />
-                  <CreateBloks blokSection={props.blok.ideal} />
+                  <CreateBloks blokSection={props.blok.dei} />
                   <CreateBloks blokSection={props.blok.law} />
                   <CreateBloks blokSection={props.blok.medicine} />
                   <CreateBloks blokSection={props.blok.science} />

--- a/src/components/page-types/oodSupportPage.js
+++ b/src/components/page-types/oodSupportPage.js
@@ -105,6 +105,13 @@ const OodSupportPage = (props) => {
                 <label htmlFor="culture">Culture, Ethics, + Service</label>
                 <input
                   type="radio"
+                  id="ideal"
+                  name="areas-to-support"
+                  onClick={updateHash}
+                />
+                <label htmlFor="ideal">IDEAL</label>
+                <input
+                  type="radio"
                   id="law"
                   name="areas-to-support"
                   onClick={updateHash}
@@ -152,6 +159,7 @@ const OodSupportPage = (props) => {
                   <CreateBloks blokSection={props.blok.athletics} />
                   <CreateBloks blokSection={props.blok.business} />
                   <CreateBloks blokSection={props.blok.culture} />
+                  <CreateBloks blokSection={props.blok.ideal} />
                   <CreateBloks blokSection={props.blok.law} />
                   <CreateBloks blokSection={props.blok.medicine} />
                   <CreateBloks blokSection={props.blok.science} />

--- a/src/scss/core/_base.scss
+++ b/src/scss/core/_base.scss
@@ -8,6 +8,7 @@ html {
 
 body {
   width: 100%;
+  overflow-x: clip;
 }
 
 a {

--- a/src/scss/page-types/_support-page.scss
+++ b/src/scss/page-types/_support-page.scss
@@ -84,7 +84,7 @@
       &[id="athletics"]:checked ~ div article:not([data-areas-to-support*="athletics"]),
       &[id="business"]:checked ~ div article:not([data-areas-to-support*="business"]),
       &[id="culture"]:checked ~ div article:not([data-areas-to-support*="culture"]),
-      &[id="ideal"]:checked ~ div article:not([data-areas-to-support*="ideal"]),
+      &[id="dei"]:checked ~ div article:not([data-areas-to-support*="dei"]),
       &[id="law"]:checked ~ div article:not([data-areas-to-support*="law"]),
       &[id="medicine"]:checked ~ div article:not([data-areas-to-support*="medicine"]),
       &[id="science"]:checked ~ div article:not([data-areas-to-support*="science"]),

--- a/src/scss/page-types/_support-page.scss
+++ b/src/scss/page-types/_support-page.scss
@@ -84,6 +84,7 @@
       &[id="athletics"]:checked ~ div article:not([data-areas-to-support*="athletics"]),
       &[id="business"]:checked ~ div article:not([data-areas-to-support*="business"]),
       &[id="culture"]:checked ~ div article:not([data-areas-to-support*="culture"]),
+      &[id="ideal"]:checked ~ div article:not([data-areas-to-support*="ideal"]),
       &[id="law"]:checked ~ div article:not([data-areas-to-support*="law"]),
       &[id="medicine"]:checked ~ div article:not([data-areas-to-support*="medicine"]),
       &[id="science"]:checked ~ div article:not([data-areas-to-support*="science"]),


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- Add Diversity, Equity, + inclusion category to areas to support page (in the filter), and that the user can add a card under the Diversity, Equity, + inclusion category as well.
- Fix a weird double scroll bar bug that I see on the Areas to support page

# Review By (Date)
- Sooner the better so we can get this into PROD for Giving Tuesday

# Review Tasks

## Setup tasks and/or behavior to test

1. Go to https://deploy-preview-300--adapt-giving.netlify.app/areas-to-support/
2. Confirm that you see the Diversity, Equity, + inclusion category button
3. Click on it, and it should show the only one card which is in this category
4. The URL should update with the #dei hash as well
5. You shouldn't see any weird double vertical scroll bar like on 
https://giving.stanford.edu/areas-to-support/
If you click on Athletics for example
![Screen Shot 2022-11-10 at 9 42 18 AM](https://user-images.githubusercontent.com/42749717/201168128-cea3dd1b-198e-4199-b251-758f5e9e5d10.png)


# Affected Projects or Products
- Does this PR impact any particular projects, products, or modules?

# Associated Issues and/or People
- ADAPT-5488
