### PR TITLE
DS-560 | Add option to center campaign page hero content when the fullwidth image layout is selected

### DIFF
--- a/src/components/partials/campaignHero.js
+++ b/src/components/partials/campaignHero.js
@@ -50,11 +50,15 @@ const CampaignHero = (props) => {
         <div className="campaign-page__image-wrapper">{full_width_image}</div>
         <div className={campaignContentClasses}>
           <div
-            className={`campaign-page__hero-content-wrapper ${
+            className={cx(
+              'campaign-page__hero-content-wrapper',
               isFullWidthImage
                 ? 'flex-md-9-of-12 flex-lg-6-of-12 column-grid__column'
+                : '',
+              blok.heroContentPosition === 'center' && isFullWidthImage
+                ? 'su-mx-auto'
                 : ''
-            }`}
+            )}
           >
             {blok.logo?.filename && (
               <img


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- Add an option to center the hero content box (currently only left or right aligned) to the Campaign page hero
- https://stanford.atlassian.net/browse/DS-560

# Review By (Date)
- End of the week Mar 15

# Criticality
- 3

# Review Tasks

## Setup tasks and/or behavior to test

1. Go to https://deploy-preview-406--adapt-giving.netlify.app/campaign-test/ and check that the box in the hero banner is centered
![Screenshot 2024-03-13 at 6 04 44 PM](https://github.com/SU-SWS/ood_giving_site/assets/42749717/e7ac42d0-8aa8-456c-94c9-95c94174f0cb)
2. Check responsive
2. You can also go to Storyblok giving DEV, go to the campaign-test page, and play with the Hero Content Position option (under Hero content styling group)
![Screenshot 2024-03-13 at 6 04 35 PM](https://github.com/SU-SWS/ood_giving_site/assets/42749717/9aba9f1d-e759-4ef3-88c6-ef37cac0196c)
3. Check that the original left and right options are still working as before.


# Associated Issues and/or People
- DS-560 https://stanford.atlassian.net/browse/DS-560