### PR TITLE
DS-748 | @ericbakenhus | Check for empty array before outputing menu

### DIFF
--- a/src/components/navigation/contentMenu/oodContentMenu.js
+++ b/src/components/navigation/contentMenu/oodContentMenu.js
@@ -31,7 +31,7 @@ const OodContentMenu = (props) => {
   const Menus = (props) => (
     <>
       <div className={`ood-content-nav__menu-group`}>
-        {!!props.blok.menuTitle?.length && (
+        {props.blok.menuTitle && (
           <Heading level={'h2'} classes={`ood-content-nav__title`}>
             {props.blok.menuTitle}
           </Heading>

--- a/src/components/navigation/contentMenu/oodContentMenu.js
+++ b/src/components/navigation/contentMenu/oodContentMenu.js
@@ -31,7 +31,7 @@ const OodContentMenu = (props) => {
   const Menus = (props) => (
     <>
       <div className={`ood-content-nav__menu-group`}>
-        {props.blok.menuTitle && (
+        {!!props.blok.menuTitle?.length && (
           <Heading level={'h2'} classes={`ood-content-nav__title`}>
             {props.blok.menuTitle}
           </Heading>
@@ -40,7 +40,7 @@ const OodContentMenu = (props) => {
           <CreateBloks blokSection={props.blok.menuLinks} />
         </ul>
       </div>
-      {props.blok.relatedMenuLinks && (
+      {!!props.blok.relatedMenuLinks?.length && (
         <div className={`ood-content-nav__menu-group`}>
           {props.blok.relatedMenuTitle && (
             <Heading level={'h2'} classes={`ood-content-nav__title`}>


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- Related menu currently checks that the link array exists before outputting `ul`; switches to checking that the array exists _and_ is not empty

# Review By (Date)
- Soon-ish

# Criticality
- Medium (level A on a lot of pages)

# Review Tasks

## Setup tasks and/or behavior to test

1. Look at code

# Associated Issues and/or People
- DS-748
