### PR TITLE
DS-1112 | Do not use heading for support card and icon card headlines

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6088,9 +6088,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001562",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001562.tgz",
-      "integrity": "sha512-kfte3Hym//51EdX4239i+Rmp20EsLIYGdPkERegTgU19hQWCRhsRFGKHTliUlsry53tv17K7n077Kqa0WJU4ng==",
+      "version": "1.0.30001706",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001706.tgz",
+      "integrity": "sha512-3ZczoTApMAZwPKYWmwVbQMFpXBDds3/0VciVoUwPUbldlYyVLmRVuRs/PcUZtHpbLRpzzDvrvnFuREsGt6lUug==",
       "funding": [
         {
           "type": "opencollective",
@@ -6104,7 +6104,8 @@
           "type": "github",
           "url": "https://github.com/sponsors/ai"
         }
-      ]
+      ],
+      "license": "CC-BY-4.0"
     },
     "node_modules/capital-case": {
       "version": "1.0.4",
@@ -40286,9 +40287,9 @@
       }
     },
     "caniuse-lite": {
-      "version": "1.0.30001562",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001562.tgz",
-      "integrity": "sha512-kfte3Hym//51EdX4239i+Rmp20EsLIYGdPkERegTgU19hQWCRhsRFGKHTliUlsry53tv17K7n077Kqa0WJU4ng=="
+      "version": "1.0.30001706",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001706.tgz",
+      "integrity": "sha512-3ZczoTApMAZwPKYWmwVbQMFpXBDds3/0VciVoUwPUbldlYyVLmRVuRs/PcUZtHpbLRpzzDvrvnFuREsGt6lUug=="
     },
     "capital-case": {
       "version": "1.0.4",

--- a/package.json
+++ b/package.json
@@ -77,6 +77,7 @@
     "lint:fix": "NODE_ENV=test eslint \"./src/**/*.{js,jsx,ts,tsx}\" --fix",
     "test": "echo \"Write tests! -> https://gatsby.dev/unit-testing\" && exit 1",
     "https-proxy-start": "local-ssl-proxy --source 3010 --target 8000 --cert ./dev/localhost.pem --key ./dev/localhost-key.pem",
+    "proxy": "local-ssl-proxy --source 3010 --target 8000 --cert ./dev/localhost.pem --key ./dev/localhost-key.pem",
     "hps": "local-ssl-proxy --cert ./dev/localhost.pem --key ./dev/localhost-key.pem"
   },
   "repository": {

--- a/src/components/cards/oodIconCard.js
+++ b/src/components/cards/oodIconCard.js
@@ -1,57 +1,56 @@
 import React from 'react';
 import SbEditable from 'storyblok-react';
-import Heading from '../partials/heading';
 import SbLink from '../partials/sbLink';
+import cx from 'classnames';
 
 const OodIconCard = (props) => {
   return (
     <SbEditable content={props.blok}>
       <article
-        className={`ood-icon-card
-             ${props.blok.backgroundColor !== 'white' ? 'su-text-white' : ''}
-             su-text-align-${props.blok.contentAlign}`}
+        className={cx(
+          'ood-icon-card',
+          props.blok.backgroundColor !== 'white' ? 'su-text-white' : '',
+          `su-text-align-${props.blok.contentAlign}`
+        )}
       >
         <SbLink
           link={props.blok.link}
-          classes={`ood-icon-card__link su-bg-${props.blok.backgroundColor}
-            ${
-              props.blok.backgroundColor === 'white'
-                ? 'su-border-color-black-10'
-                : `su-border-color-${props.blok.backgroundColor}`
-            }`}
+          classes={cx(
+            'ood-icon-card__link',
+            `su-bg-${props.blok.backgroundColor}`,
+            props.blok.backgroundColor === 'white'
+              ? 'su-border-color-black-10'
+              : `su-border-color-${props.blok.backgroundColor}`
+          )}
         >
           <div className="ood-icon-card__media">
             <span
               aria-hidden="true"
-              className={`ood-icon-card__icon
-                  ${
-                    props.blok.iconStyle
-                      ? props.blok.iconStyle
-                      : props.blok.icon.type
-                  }
-                  ${
-                    props.blok.extraIcon
-                      ? `fa-${props.blok.extraIcon}`
-                      : props.blok.icon.icon
-                  }
-                  ${
-                    props.blok.backgroundColor !== 'white'
-                      ? 'su-text-white'
-                      : 'su-text-digital-red'
-                  }`}
+              className={cx(
+                'ood-icon-card__icon',
+                props.blok.iconStyle
+                  ? props.blok.iconStyle
+                  : props.blok.icon.type,
+                props.blok.extraIcon
+                  ? `fa-${props.blok.extraIcon}`
+                  : props.blok.icon.icon,
+                props.blok.backgroundColor !== 'white'
+                  ? 'su-text-white'
+                  : 'su-text-digital-red'
+              )}
             />
           </div>
           <div className="ood-icon-card__contents">
-            <Heading
-              level={props.blok.headingLevel}
-              defaultLevel={'h3'}
-              classes={'ood-icon-card__headline su-hocus-underline su-mb-none'}
-              weight={'semibold'}
-              external={props.blok.link.linktype === 'url'}
-              color={props.blok.backgroundColor !== 'white' ? 'white' : 'black'}
+            <span
+              className={cx(
+                'ood-icon-card__headline su-hocus-underline su-mb-none',
+                props.blok.backgroundColor !== 'white'
+                  ? 'su-text-white'
+                  : 'su-text-black'
+              )}
             >
               {props.blok.headline}
-            </Heading>
+            </span>
           </div>
         </SbLink>
       </article>

--- a/src/components/cards/oodSupportCard.js
+++ b/src/components/cards/oodSupportCard.js
@@ -10,7 +10,7 @@ const OodSupportCard = (props) => {
 
   return (
     <SbEditable content={props.blok}>
-      <div
+      <article
         className="ood-support-card su-text-white su-text-align-left"
         data-areas-to-support={taxonomyString(props.blok.taxonomy)}
       >
@@ -44,7 +44,7 @@ const OodSupportCard = (props) => {
             />
           </div>
         </SbLink>
-      </div>
+      </article>
     </SbEditable>
   );
 };

--- a/src/components/cards/oodSupportCard.js
+++ b/src/components/cards/oodSupportCard.js
@@ -10,26 +10,22 @@ const OodSupportCard = (props) => {
 
   return (
     <SbEditable content={props.blok}>
-      <article
+      <div
         className={`ood-support-card su-text-white su-text-align-left`}
         data-areas-to-support={taxonomyString(props.blok.taxonomy)}
       >
         <SbLink
           link={props.blok.link}
-          classes={`ood-support-card__link su-bg-${props.blok.backgroundColor}`}
+          classes={`ood-support-card__link su-text-white su-bg-${props.blok.backgroundColor}`}
         >
           <div className="ood-support-card__contents">
-            <Heading
-              level={props.blok.headingLevel}
-              defaultLevel={'h3'}
-              color={'white'}
-              weight={'semibold'}
+            <span
               classes={`ood-support-card__headline ${
                 props.blok.link.linktype === 'url' ? 'su-link--external' : ''
               }`}
             >
               {props.blok.headline}
-            </Heading>
+            </span>
             <span
               aria-hidden="true"
               className={`ood-support-card__icon su-text-white
@@ -47,7 +43,7 @@ const OodSupportCard = (props) => {
             />
           </div>
         </SbLink>
-      </article>
+      </div>
     </SbEditable>
   );
 };

--- a/src/components/cards/oodSupportCard.js
+++ b/src/components/cards/oodSupportCard.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import SbEditable from 'storyblok-react';
-import Heading from '../partials/heading';
 import SbLink from '../partials/sbLink';
+import cx from 'classnames';
 
 const OodSupportCard = (props) => {
   const taxonomyString = (taxonomyArray) => {
@@ -11,35 +11,36 @@ const OodSupportCard = (props) => {
   return (
     <SbEditable content={props.blok}>
       <div
-        className={`ood-support-card su-text-white su-text-align-left`}
+        className="ood-support-card su-text-white su-text-align-left"
         data-areas-to-support={taxonomyString(props.blok.taxonomy)}
       >
         <SbLink
           link={props.blok.link}
-          classes={`ood-support-card__link su-text-white su-bg-${props.blok.backgroundColor}`}
+          classes={cx(
+            'ood-support-card__link',
+            `su-bg-${props.blok.backgroundColor}`
+          )}
         >
           <div className="ood-support-card__contents">
             <span
-              classes={`ood-support-card__headline ${
+              className={cx(
+                'ood-support-card__headline su-text-white',
                 props.blok.link.linktype === 'url' ? 'su-link--external' : ''
-              }`}
+              )}
             >
               {props.blok.headline}
             </span>
             <span
               aria-hidden="true"
-              className={`ood-support-card__icon su-text-white
-                  ${
-                    props.blok.iconStyle
-                      ? props.blok.iconStyle
-                      : props.blok.icon.type
-                  }
-                  ${
-                    props.blok.extraIcon
-                      ? `fa-${props.blok.extraIcon}`
-                      : props.blok.icon.icon
-                  }
-        `}
+              className={cx(
+                'ood-support-card__icon su-text-white',
+                props.blok.iconStyle
+                  ? props.blok.iconStyle
+                  : props.blok.icon.type,
+                props.blok.extraIcon
+                  ? `fa-${props.blok.extraIcon}`
+                  : props.blok.icon.icon
+              )}
             />
           </div>
         </SbLink>


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- Use span instead of HTML heading for Support Cards and Icon Cards

# Review By (Date)
- Before end of sprint

# Criticality
- 5

# Review Tasks

## Setup tasks and/or behavior to test

1. Go to https://deploy-preview-476--adapt-giving.netlify.app/areas-to-support/
2. Look at the Areas to Support cards (the colored ones). Inspect the headline - they should be a span instead of heading now.
3. Check that they look the same as on the live site https://giving.stanford.edu/areas-to-support/
4. Repeat the same for the icon cards in the ankle (the white cards)

# Associated Issues and/or People
- [DS-1112 ](https://stanford.atlassian.net/browse/DS-1112)
