### PR TITLE
Release: v4.2.8

### DIFF
--- a/endowed-positions.md
+++ b/endowed-positions.md
@@ -1,0 +1,26 @@
+# Endowed Positions
+
+Endowed Positions is a subsection of the Stanford Giving site. 
+
+The main route `/endowed-positions` is a page built via Storyblok. The sub-routes are built and controlled via Gatsby. Each school, center, institute, or program has its own sub-route, i.e. `/endowed-positions/graduate-school-of-business`. Schools/centers are added or removed via [ENDOWED_POSITIONS_MAP.json](https://github.com/SU-SWS/ood_giving_site/blob/dev/src/constants/ENDOWED_POSITIONS_MAP.json).
+
+Search results are another sub-route, i.e. `/endowed-positions/search?term=james`. This route will provide a list of results, each of which is clickable. When one of the results is clicked, a query param of the results' index is appended, and the UI is changed to show only that result. There were potential plans to expand this, but this functionality matched that of the previous Endowed Positions site. Search is powered by [Fuse.js](https://www.fusejs.io/).
+
+## Endowed Positions Files
+
+- [React component files](https://github.com/SU-SWS/ood_giving_site/tree/dev/src/components/endowed-positions)
+- [Dataset JSON](https://github.com/SU-SWS/ood_giving_site/blob/dev/src/fixtures/endowedPositions.json)
+- [School/Center Map JSON](https://github.com/SU-SWS/ood_giving_site/blob/dev/src/constants/ENDOWED_POSITIONS_MAP.json)
+
+## Updating the Endowed Positions dataset
+
+The Endowed Positions dataset is updated about 6 times a year. Every few months, an updated CSV will be provided by the team that manages the data. The site will need the updated data from the CSV. The following are steps to update the site data once a new CSV is received:
+
+1. Convert CSV to JSON using a tool such as ([csvjson](https://csvjson.com/csv2json))
+2. Replace the existing data file with the new one, keeping the same name [endowedPositions.json](https://github.com/SU-SWS/ood_giving_site/blob/dev/src/fixtures/endowedPositions.json)
+3. Update the footer's dates. The updated date is the day the developer makes the change. ([EndowedPositionsFooter.js](https://github.com/SU-SWS/ood_giving_site/blob/dev/src/components/endowed-positions/EndowedPositionsFooter.js))
+4. Once updated, create a pull request and send the preview build URL to the approver [Forrest Glick](https://github.com/forrestglick)
+5. When approved, merge into the dev branch and cut a release for production
+6. Release to production on the date and time agreed upon with the [approver](https://github.com/forrestglick)
+
+* [Sample PR](https://github.com/SU-SWS/ood_giving_site/pull/484) 

--- a/src/fixtures/endowedPositions.json
+++ b/src/fixtures/endowedPositions.json
@@ -2424,7 +2424,7 @@
   {
     "Key": "H&SKBCQX3822921",
     "SUBCATEGORY": "SCHOOL OF HUMANITIES AND SCIENCES",
-    "POSITION": "The Joan Danforth Professorship",
+    "POSITION": "The Joan Danforth Professorship in History",
     "CURRENT HOLDER": "David Como",
     "WEBSITE": "http://humsci.stanford.edu"
   },


### PR DESCRIPTION
# Release V4.2.8

This pull request introduces a new documentation file for the Endowed Positions section of the Stanford Giving site and updates a dataset entry to provide more specific information about a professorship. Below are the key changes:

### Documentation for Endowed Positions

* Added `endowed-positions.md` to document the structure, routes, and update process for the Endowed Positions section. This includes details on the main route, sub-routes, search functionality, and steps for updating the dataset.

### Dataset Update

* Updated the `POSITION` field in `src/fixtures/endowedPositions.json` to include more specific information, changing "The Joan Danforth Professorship" to "The Joan Danforth Professorship in History."