### PR TITLE
DS-1500 | Embed Script component

### DIFF
--- a/components/EmbedScript.tsx
+++ b/components/EmbedScript.tsx
@@ -1,0 +1,58 @@
+'use client';
+
+import { useRef, useEffect, useCallback } from 'react';
+
+/**
+ * For embedding HTML content and third-party scripts.
+ *
+ * Credit where credit is deserved.
+ * @see: https://github.com/christo-pr/dangerously-set-html-content
+ *
+ * Use this widget with caution. There are no safeguards on what it can do. It
+ * is also not good practice to inject and manipulate the page outside of
+ * React as that can lead to irregularities and troubles.
+ */
+
+type EmbedScriptProps = React.HTMLAttributes<HTMLDivElement> & {
+  script?: string;
+}
+
+export const EmbedScript = ({
+  script: html,
+  className,
+  ...props
+}: EmbedScriptProps) => {
+  const containerRef = useRef<HTMLDivElement>(null);
+
+  const injectContent = useCallback(() => {
+    if (!html || !containerRef.current) return;
+
+    try {
+      // Create a 'tiny' document and parse the html string.
+      // https://developer.mozilla.org/en-US/docs/Web/API/DocumentminiDom
+      const miniDom = document.createRange().createContextualFragment(html);
+
+      // Force the scripts in the embed script field to load sync.
+      const scripts = miniDom.querySelectorAll('script');
+      for (const script of scripts) {
+        if (script.src && script.src.length > 0) {
+          script.async = false;
+          script.defer = false;
+        }
+      }
+
+      // Clear the container and append new content
+      containerRef.current.replaceChildren(miniDom);
+    } catch (error) {
+      console.error('EmbedScript: Failed to inject content', error);
+    }
+  }, [html]);
+
+  useEffect(() => {
+    injectContent();
+  }, [injectContent]);
+
+  return (
+    <div ref={containerRef} className={className} {...props} />
+  );
+};

--- a/components/Storyblok/SbEmbedScript.tsx
+++ b/components/Storyblok/SbEmbedScript.tsx
@@ -1,0 +1,12 @@
+import { SbBlokData, storyblokEditable } from '@storyblok/react/rsc';
+import { EmbedScript } from '@/components/EmbedScript';
+
+type SbEmbedScriptProps = {
+  blok: SbBlokData & {
+    script?: string;
+  };
+};
+
+export const SbEmbedScript = (props: SbEmbedScriptProps) => (
+  <EmbedScript {...storyblokEditable(props.blok)} script={props.blok.script} />
+);

--- a/utilities/storyblok.tsx
+++ b/utilities/storyblok.tsx
@@ -1,5 +1,6 @@
 import { apiPlugin, storyblokInit } from '@storyblok/react/rsc';
 import { ComponentNotFound } from '@/components/Storyblok/ComponentNotFound';
+import { SbEmbedScript } from '@/components/Storyblok/SbEmbedScript';
 import { SbGlobalFooter } from '@/components/Storyblok/SbGlobalFooter';
 import { SbLandingPage } from '@/components/Storyblok/SbLandingPage';
 import { SbGlobalFooterPicker } from '@/components/Storyblok/SbGlobalFooterPicker';
@@ -39,6 +40,7 @@ export const components = {
   storyPicker: SbStoryPicker,
   ctaLink: SbCtaLink,
   ctaGroup: SbCtaGroup,
+  embedScript: SbEmbedScript,
   navItem: SbNavItem,
   lockup: SbLockup,
   // Cards


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- Add Embed Script component
- Note: this should allow the airtable form in DS-1419 to be embedded as an iframe


# Review By (Date)
- Soon

# Criticality
- 7

# Review Tasks

## Setup tasks and/or behavior to test

1. Go to this page and check for example, this embedded widget works
https://deploy-preview-509--adapt-giving.netlify.app/the-stanford-fund/dollars-for-doers-challenge
![Screenshot 2025-06-24 at 12 51 50 PM](https://github.com/user-attachments/assets/dbcdc1f7-997c-4ee3-810a-88876ec349dc)

2. And for example this planned giving calculator should work too
https://deploy-preview-509--adapt-giving.netlify.app/planned-giving/calculator
![Screenshot 2025-06-24 at 12 53 45 PM](https://github.com/user-attachments/assets/a4961d5c-32b3-45eb-8ecb-093712385fd0)

3. Then test that these HTML tables render (ignore the color issue because the wrapper Section hasn't been styled)
https://deploy-preview-509--adapt-giving.netlify.app/life-income/compare


# Associated Issues and/or People
- DS-1500
