### PR TITLE
DS-1436 DS-1494 | FontAwesome, Icon Card, Icon Card Section

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -6,6 +6,11 @@ import { FlexBox } from '@/components/FlexBox';
 import { GAProvider, GTAG } from '@/components/GAProvider';
 import { SearchModalProvider } from '@/components/Search/Modal/SearchModalContext';
 
+// https://docs.fontawesome.com/web/use-with/react/use-with#getting-font-awesome-css-to-work
+import { config } from '@fortawesome/fontawesome-svg-core';
+import '@fortawesome/fontawesome-svg-core/styles.css';
+config.autoAddCss = false;
+
 type LayoutProps = {
   children: React.ReactNode,
 };

--- a/components/Container/Container.styles.ts
+++ b/components/Container/Container.styles.ts
@@ -6,6 +6,7 @@ export const widths = {
 
 export const bgColors = {
   black: 'bg-black text-white',
+  'black-10': 'bg-black-10 text-black',
   white: 'bg-white text-black',
   'fog-light': 'bg-fog-light text-black',
 };

--- a/components/Container/Container.tsx
+++ b/components/Container/Container.tsx
@@ -1,7 +1,14 @@
 import { HTMLAttributes } from 'react';
 import { cnb } from 'cnbuilder';
 import {
-  paddingTops, paddingBottoms, type PaddingType, marginTops, marginBottoms, type MarginType,
+  marginTops,
+  marginBottoms,
+  marginVerticals,
+  paddingTops,
+  paddingBottoms,
+  paddingVerticals,
+  type PaddingType,
+  type MarginType,
 } from '@/utilities/datasource';
 import * as styles from './Container.styles';
 import * as types from './Container.types';
@@ -10,8 +17,10 @@ export type ContainerProps = HTMLAttributes<HTMLElement> & {
   as?: types.ContainerElementType;
   mt?: MarginType;
   mb?: MarginType;
+  my?: MarginType;
   pt?: PaddingType;
   pb?: PaddingType;
+  py?: PaddingType;
   width?: types.WidthType;
   bgColor?: types.BgColorType;
   style?: React.CSSProperties;
@@ -24,8 +33,10 @@ export const Container = ({
   style,
   mt,
   mb,
+  my,
   pt,
   pb,
+  py,
   className,
   children,
   ...props
@@ -36,10 +47,12 @@ export const Container = ({
     className={cnb(
       bgColor ? styles.bgColors[bgColor] : '',
       width ? styles.widths[width] : '',
-      mt ? marginTops[mt] : '',
-      mb ? marginBottoms[mb] : '',
+      py ? paddingVerticals[py] : '',
       pt ? paddingTops[pt] : '',
       pb ? paddingBottoms[pb] : '',
+      mt ? marginTops[mt] : '',
+      mb ? marginBottoms[mb] : '',
+      my ? marginVerticals[my] : '',
       className,
     )}
   >

--- a/components/FAIcon/FAIcon.tsx
+++ b/components/FAIcon/FAIcon.tsx
@@ -1,0 +1,32 @@
+import { library, type IconName } from '@fortawesome/fontawesome-svg-core';
+import { fas } from '@fortawesome/free-solid-svg-icons';
+import { far } from '@fortawesome/free-regular-svg-icons';
+import { FontAwesomeIcon, type FontAwesomeIconProps } from '@fortawesome/react-fontawesome';
+
+export type FAIconProps = Omit<FontAwesomeIconProps, 'icon'> & {
+  icon: IconName;
+  // For this project we only use the free outline "far" or solid "fas" icons
+  iconStyle?: 'far' | 'fas';
+  // Optional title for accessibility. Add title if icon is not decorative only.
+  title?: string;
+}
+
+export const FAIcon = ({
+  icon,
+  iconStyle,
+  title,
+  ...props
+}: FAIconProps) => {
+  if (!icon) {
+    return null;
+  }
+
+  // Add both free solid and regular FA icons to the library so we can use any of them
+  library.add(fas, far);
+
+  const faStyle = iconStyle || 'far';
+
+  return (
+    <FontAwesomeIcon {...props} title={title} icon={[faStyle, icon]} />
+  );
+};

--- a/components/FAIcon/FAIcon.tsx
+++ b/components/FAIcon/FAIcon.tsx
@@ -1,19 +1,27 @@
 import { library, type IconName } from '@fortawesome/fontawesome-svg-core';
-import { fas } from '@fortawesome/free-solid-svg-icons';
 import { far } from '@fortawesome/free-regular-svg-icons';
+import { fas } from '@fortawesome/free-solid-svg-icons';
 import { FontAwesomeIcon, type FontAwesomeIconProps } from '@fortawesome/react-fontawesome';
 
+/**
+ * We use FontAwesome icons in Icon Cards, Support Card and other components.
+ * See setup instructions and usage:
+ * https://docs.fontawesome.com/web/use-with/react/add-icons
+ * https://docs.fontawesome.com/web/use-with/react/style
+ */
 export type FAIconProps = Omit<FontAwesomeIconProps, 'icon'> & {
   icon: IconName;
   // For this project we only use the free outline "far" or solid "fas" icons
   iconStyle?: 'far' | 'fas';
-  // Optional title for accessibility. Add title if icon is not decorative only.
-  title?: string;
 }
 
 export const FAIcon = ({
   icon,
   iconStyle,
+  /**
+   * Optional svg title for accessibility. Add title if icon is not decorative.
+   * Icon is aria-hidden unless a title is provided.
+   */
   title,
   ...props
 }: FAIconProps) => {
@@ -22,7 +30,7 @@ export const FAIcon = ({
   }
 
   // Add both free solid and regular FA icons to the library so we can use any of them
-  library.add(fas, far);
+  library.add(far, fas);
 
   const faStyle = iconStyle || 'far';
 

--- a/components/FAIcon/index.ts
+++ b/components/FAIcon/index.ts
@@ -1,0 +1,1 @@
+export * from './FAIcon';

--- a/components/FlexBox/FlexBox.tsx
+++ b/components/FlexBox/FlexBox.tsx
@@ -1,5 +1,15 @@
 import React, { ReactNode, HTMLAttributes, forwardRef } from 'react';
 import { cnb } from 'cnbuilder';
+import {
+  marginTops,
+  marginBottoms,
+  marginVerticals,
+  paddingTops,
+  paddingBottoms,
+  paddingVerticals,
+  type PaddingType,
+  type MarginType,
+} from '@/utilities/datasource';
 import * as styles from './FlexBox.styles';
 import * as types from './FlexBox.types';
 
@@ -12,6 +22,12 @@ type FlexBoxProps = HTMLAttributes<HTMLElement> & {
   alignContent?: types.FlexAlignContentType;
   alignItems?: types.FlexAlignItemsType;
   children?: ReactNode;
+  mt?: MarginType;
+  mb?: MarginType;
+  my?: MarginType;
+  pt?: PaddingType;
+  pb?: PaddingType;
+  py?: PaddingType;
 };
 
 export const FlexBox = forwardRef<HTMLElement, FlexBoxProps>(({
@@ -22,6 +38,12 @@ export const FlexBox = forwardRef<HTMLElement, FlexBoxProps>(({
   justifyContent,
   alignContent,
   alignItems,
+  mt,
+  mb,
+  my,
+  pt,
+  pb,
+  py,
   children,
   className,
   ...props
@@ -37,6 +59,12 @@ export const FlexBox = forwardRef<HTMLElement, FlexBoxProps>(({
       alignContent ? styles.flexAlignContent[alignContent] : '',
       alignItems ? styles.flexAlignItems[alignItems] : '',
       gap ? 'grid-gap' : '',
+      py ? paddingVerticals[py] : '',
+      pt ? paddingTops[pt] : '',
+      pb ? paddingBottoms[pb] : '',
+      mt ? marginTops[mt] : '',
+      mb ? marginBottoms[mb] : '',
+      my ? marginVerticals[my] : '',
       className,
     )}
   >

--- a/components/IconCard/IconCard.styles.ts
+++ b/components/IconCard/IconCard.styles.ts
@@ -8,13 +8,16 @@ export const align = {
 };
 export type ContentAlignType = keyof typeof align;
 
+// TODO DS-1433: Container query for smaller x padding when card is narrow
 export const root = (backgroundColor: CardBgColorType) => cnb(
-    'relative break-words mx-auto sm:w-3/4 rs-px-3 w-full shadow-md focus-within:shadow-lg hover:shadow-lg transition-shadow',
-    cardBgColors[backgroundColor || 'white'],
-    backgroundColor === 'white' ? 'text-black' : 'text-white',
+  'relative print:hidden break-words mx-auto sm:w-3/4 rs-px-3 w-full shadow-md focus-within:shadow-lg hover:shadow-lg transition-shadow',
+  cardBgColors[backgroundColor || 'white'],
+  backgroundColor === 'white' ? 'text-black' : 'text-white',
 );
 
-export const icon = (backgroundColor: CardBgColorType) => cnb(
-  'text-[2em]',
-  backgroundColor === 'white' ? 'text-digital-red' : 'text-white',
+export const link = (backgroundColor: CardBgColorType) => cnb(
+  'stretched-link *:hocus:underline outline-none focus-visible:after:outline focus-visible:after:outline-digital-blue',
+  backgroundColor === 'white' ? '*:hocus:text-digital-red' : '*:hocus:text-white',
 );
+
+export const icon = (backgroundColor: CardBgColorType) => backgroundColor === 'white' ? 'text-digital-red' : 'text-white';

--- a/components/IconCard/IconCard.styles.ts
+++ b/components/IconCard/IconCard.styles.ts
@@ -1,0 +1,20 @@
+import { cnb } from 'cnbuilder';
+import { cardBgColors, type CardBgColorType } from '@/utilities/datasource';
+
+export const align = {
+  left: 'start',
+  center: 'center',
+  right: 'end',
+};
+export type ContentAlignType = keyof typeof align;
+
+export const root = (backgroundColor: CardBgColorType) => cnb(
+    'relative rs-px-3 w-full shadow-md',
+    cardBgColors[backgroundColor || 'white'],
+    backgroundColor === 'white' ? 'text-black' : 'text-white',
+);
+
+export const icon = (backgroundColor: CardBgColorType) => cnb(
+  'text-[2em]',
+  backgroundColor === 'white' ? 'text-digital-red' : 'text-white',
+);

--- a/components/IconCard/IconCard.styles.ts
+++ b/components/IconCard/IconCard.styles.ts
@@ -9,7 +9,7 @@ export const align = {
 export type ContentAlignType = keyof typeof align;
 
 export const root = (backgroundColor: CardBgColorType) => cnb(
-    'relative rs-px-3 w-full shadow-md',
+    'relative break-words mx-auto sm:w-3/4 rs-px-3 w-full shadow-md focus-within:shadow-lg hover:shadow-lg transition-shadow',
     cardBgColors[backgroundColor || 'white'],
     backgroundColor === 'white' ? 'text-black' : 'text-white',
 );

--- a/components/IconCard/IconCard.tsx
+++ b/components/IconCard/IconCard.tsx
@@ -1,0 +1,48 @@
+import { FAIcon, type FAIconProps } from '@/components/FAIcon';
+import { FlexBox, type FlexAlignItemsType } from '@/components/FlexBox';
+import { SbLink } from '@/components/Storyblok/partials/SbLink';
+import { Text } from '@/components/Typography';
+import { type SbLinkType } from '@/components/Storyblok/Storyblok.types';
+import { type CardBgColorType } from '@/utilities/datasource';
+import * as styles from './IconCard.styles';
+
+type IconCardProps = React.HTMLAttributes<HTMLDivElement> & FAIconProps & {
+  headline: string;
+  link: SbLinkType;
+  backgroundColor?: CardBgColorType;
+  contentAlign?: styles.ContentAlignType;
+}
+
+export const IconCard = ({
+  icon,
+  iconStyle,
+  title,
+  headline,
+  link,
+  backgroundColor,
+  contentAlign = 'center',
+}: IconCardProps) => {
+  return (
+    <FlexBox
+      direction="col"
+      alignItems={styles.align[contentAlign] as FlexAlignItemsType}
+      pt={4}
+      pb={5}
+      className={styles.root(backgroundColor)}
+    >
+      <FAIcon icon={icon} iconStyle={iconStyle} title={title} className={styles.icon(backgroundColor)} />
+      <SbLink link={link} classes="stretched-link">
+        <Text
+          as="span"
+          size={2}
+          weight="semibold"
+          color={backgroundColor === 'white' ? 'black' : 'white'}
+          mt={2}
+          className="inline-block"
+        >
+          {headline}
+        </Text>
+      </SbLink>
+    </FlexBox>
+  );
+};

--- a/components/IconCard/IconCard.tsx
+++ b/components/IconCard/IconCard.tsx
@@ -30,8 +30,8 @@ export const IconCard = ({
       pb={5}
       className={styles.root(backgroundColor)}
     >
-      <FAIcon icon={icon} iconStyle={iconStyle} title={title} className={styles.icon(backgroundColor)} />
-      <SbLink link={link} classes="stretched-link *:hocus:underline">
+      <FAIcon icon={icon} iconStyle={iconStyle} title={title} size="2x" className={styles.icon(backgroundColor)} />
+      <SbLink link={link} classes={styles.link(backgroundColor)}>
         <Text
           as="span"
           size={2}

--- a/components/IconCard/IconCard.tsx
+++ b/components/IconCard/IconCard.tsx
@@ -31,13 +31,14 @@ export const IconCard = ({
       className={styles.root(backgroundColor)}
     >
       <FAIcon icon={icon} iconStyle={iconStyle} title={title} className={styles.icon(backgroundColor)} />
-      <SbLink link={link} classes="stretched-link">
+      <SbLink link={link} classes="stretched-link *:hocus:underline">
         <Text
           as="span"
           size={2}
           weight="semibold"
           color={backgroundColor === 'white' ? 'black' : 'white'}
-          mt={2}
+          mt={1}
+          align={contentAlign}
           className="inline-block"
         >
           {headline}

--- a/components/IconCard/index.ts
+++ b/components/IconCard/index.ts
@@ -1,0 +1,1 @@
+export * from './IconCard';

--- a/components/Image/StoryImage.tsx
+++ b/components/Image/StoryImage.tsx
@@ -1,7 +1,7 @@
 import { cnb } from 'cnbuilder';
 import { useMemo } from 'react';
 import { MediaWrapper, type MediaWrapperProps } from '@/components/Media';
-import { type LightPageBgColorsType } from '@/utilities/datasource';
+import { type LightPageBgColorType } from '@/utilities/datasource';
 import { getImageSources } from '@/utilities/getImageSources';
 import { getSbImageSize } from '@/utilities/getSbImageSize';
 import * as styles from './Image.styles';
@@ -10,7 +10,7 @@ export type StoryImageProps = React.HTMLAttributes<HTMLDivElement> & MediaWrappe
   imageSrc: string;
   alt?: string;
   visibleVertical?: styles.VisibleVerticalType;
-  backgroundColor?: LightPageBgColorsType;
+  backgroundColor?: LightPageBgColorType;
   isCard?: boolean;
 };
 

--- a/components/Media/Caption.tsx
+++ b/components/Media/Caption.tsx
@@ -1,7 +1,7 @@
 import { cnb } from 'cnbuilder';
 import { Container } from '@/components/Container';
 import { type StoryImageWidthType } from '@/components/Image';
-import { lightPageBgColors, type LightPageBgColorsType } from '@/utilities/datasource';
+import { lightPageBgColors, type LightPageBgColorType } from '@/utilities/datasource';
 import { type TextAlignType } from '@/components/Typography';
 import * as styles from './MediaWrapper.styles';
 
@@ -17,7 +17,7 @@ export type CaptionProps = React.HTMLAttributes<HTMLDivElement> & {
   isCard?: boolean;
   // Inset the caption to centered container width when the media is edge-to-edge
   isCaptionInset?: boolean;
-  captionBgColor?: LightPageBgColorsType;
+  captionBgColor?: LightPageBgColorType;
 };
 
 export const Caption = ({

--- a/components/Media/MediaWrapper.styles.ts
+++ b/components/Media/MediaWrapper.styles.ts
@@ -1,7 +1,7 @@
 import { cnb } from 'cnbuilder';
 import { type StoryImageWidthType } from '@/components/Image';
 import { type TextAlignType } from '@/components/Typography';
-import { lightPageBgColors, type LightPageBgColorsType } from '@/utilities/datasource';
+import { lightPageBgColors, type LightPageBgColorType } from '@/utilities/datasource';
 
 export const root = 'relative flex';
 export const wrapper = (imageWidth: StoryImageWidthType) => cnb('mx-auto', imageWidth === 'su-w-full' && 'w-full');
@@ -11,7 +11,7 @@ export const captionWrapper = 'mt-0 caption';
 export const caption = (
   isCard: boolean,
   imageWidth: StoryImageWidthType,
-  captionBgColor: LightPageBgColorsType,
+  captionBgColor: LightPageBgColorType,
   captionAlign: TextAlignType,
 ) => cnb(
   '*:*:leading-display *:*:xl:leading-snug first:*:*:mt-0',

--- a/components/Search/Search.styles.ts
+++ b/components/Search/Search.styles.ts
@@ -2,5 +2,5 @@
  * Search button
  */
 export const searchButton = 'relative ml-auto shrink-0 xl:-top-6 h-40 w-40 xl:w-fit text-digital-red hocus:text-cardinal-red rounded-full xl:text-20 xl:px-20 border border-black-30 hocus:bg-black-10 transition-colors';
-export const searchButtonText = 'sr-only xl:not-sr-only leading-none xl:mr-6';
+export const searchButtonText = 'max-xl:sr-only leading-none xl:mr-6';
 export const searchButtonIcon = 'inline-block relative -top-1 w-22 lg:w-20 h-18';

--- a/components/Storyblok/PageHeader/Header.types.ts
+++ b/components/Storyblok/PageHeader/Header.types.ts
@@ -1,7 +1,7 @@
 import { type StoryblokRichtext } from 'storyblok-rich-text-react-renderer';
 import { type VisibleVerticalType } from '@/components/Image';
 import { type SbImageType } from '../Storyblok.types';
-import { type DarkBgColorsType } from '@/utilities/datasource';
+import { type DarkBgColorType } from '@/utilities/datasource';
 
 /**
  * Common page header props
@@ -9,7 +9,7 @@ import { type DarkBgColorsType } from '@/utilities/datasource';
 export type HeaderProps = React.HTMLAttributes<HTMLDivElement> & {
   title?: string;
   intro?: StoryblokRichtext;
-  headerBackgroundColor?: DarkBgColorsType;
+  headerBackgroundColor?: DarkBgColorType;
   headerLogo?: SbImageType;
   headerImage?: SbImageType;
   visibleVertical?: VisibleVerticalType;

--- a/components/Storyblok/SbColumnGrid.tsx
+++ b/components/Storyblok/SbColumnGrid.tsx
@@ -1,0 +1,7 @@
+export const SbColumnGrid = () => {
+  return (
+    <div className="bg-sky rs-p-2">
+      <h2 className="text-white type-2">Column Grid</h2>
+    </div>
+  );
+};

--- a/components/Storyblok/SbContentMenu/SbContentMenuParentItem.tsx
+++ b/components/Storyblok/SbContentMenu/SbContentMenuParentItem.tsx
@@ -36,7 +36,7 @@ export const SbContentMenuParentItem = ({ blok, slug }: SbContentMenuParentItemP
       >
         {parentItemText}
       </CtaLink>
-      <CreateBloks blokSection={nestedMenu} />
+      <CreateBloks blokSection={nestedMenu} slug={slug} />
     </li>
   );
 };

--- a/components/Storyblok/SbIconCard.tsx
+++ b/components/Storyblok/SbIconCard.tsx
@@ -26,6 +26,7 @@ type SbIconCardProps = {
 export const SbIconCard = ({ blok }: SbIconCardProps) => {
   const {
     icon,
+    extraIcon,
     iconStyle,
     headline,
     link,
@@ -35,12 +36,14 @@ export const SbIconCard = ({ blok }: SbIconCardProps) => {
 
   // Remove fa- from the icon name if it exists
   const formattedIcon = icon?.icon.replace('fa-', '');
+  const finalIcon = extraIcon || formattedIcon;
+  const iconType = iconStyle || icon?.type || 'far';
 
   return (
     <IconCard
       {...storyblokEditable(blok)}
-      icon={formattedIcon as IconName}
-      iconStyle={iconStyle}
+      icon={finalIcon as IconName}
+      iconStyle={iconType}
       headline={headline}
       link={link}
       backgroundColor={backgroundColor}

--- a/components/Storyblok/SbIconCard.tsx
+++ b/components/Storyblok/SbIconCard.tsx
@@ -1,8 +1,50 @@
-export const SbIconCard = () => {
+import { storyblokEditable, type SbBlokData } from '@storyblok/react/rsc';
+import { type IconName } from '@fortawesome/fontawesome-svg-core';
+import { IconCard } from '@/components/IconCard';
+import { type SbLinkType } from '@/components/Storyblok/Storyblok.types';
+import { type CardBgColorType } from '@/utilities/datasource';
+import { type SbFontawesomeSelectorType } from '@/components/Storyblok/Storyblok.types';
+
+/**
+ * Note: The headingLevel option is deprecated because we no longer use HTML headings for a11y.
+ */
+type SbIconCardProps = {
+  blok: SbBlokData & {
+    // The input from the Storyblok plugin FontAwesome selector
+    icon?: SbFontawesomeSelectorType;
+    // The text field from Storyblok that allow user to use icons that are not supported by the FontAwesome selector
+    extraIcon?: string;
+    // Free solid or outline style icons
+    iconStyle?: 'fas' | 'far';
+    headline: string;
+    link: SbLinkType;
+    backgroundColor?: CardBgColorType;
+    contentAlign?: 'left' | 'center' | 'right';
+  };
+}
+
+export const SbIconCard = ({ blok }: SbIconCardProps) => {
+  const {
+    icon,
+    iconStyle,
+    headline,
+    link,
+    backgroundColor,
+    contentAlign,
+  } = blok;
+
+  // Remove fa- from the icon name if it exists
+  const formattedIcon = icon?.icon.replace('fa-', '');
+
   return (
-    <div className="bg-plum-light text-white p-3 break-words rs-p-2">
-      <h2 className="type-2 text-white">Icon Card Component</h2>
-      <p className="text-white">This is a placeholder</p>
-    </div>
+    <IconCard
+      {...storyblokEditable(blok)}
+      icon={formattedIcon as IconName}
+      iconStyle={iconStyle}
+      headline={headline}
+      link={link}
+      backgroundColor={backgroundColor}
+      contentAlign={contentAlign}
+    />
   );
 };

--- a/components/Storyblok/SbInteriorPage.tsx
+++ b/components/Storyblok/SbInteriorPage.tsx
@@ -15,7 +15,7 @@ import { Heading } from '@/components/Typography';
 import { type VisibleVerticalType } from '@/components/Image';
 import { getNumBloks } from '@/utilities/getNumBloks';
 import { config } from '@/utilities/config';
-import { darkBgColors, type DarkBgColorsType, type MarginType } from '@/utilities/datasource';
+import { darkBgColors, type DarkBgColorType, type MarginType } from '@/utilities/datasource';
 import { type SbImageType } from './Storyblok.types';
 
 
@@ -26,7 +26,7 @@ export type SbInteriorPageProps = {
     title?: string;
     intro?: StoryblokRichtext;
     headerStyle?: 'has-image' | 'no-image' | 'minimal' | 'full-width-image';
-    headerBackgroundColor?: DarkBgColorsType;
+    headerBackgroundColor?: DarkBgColorType;
     headerLogo?: SbImageType;
     headerImage?: SbImageType;
     headerSpacingBottom?: MarginType;
@@ -60,7 +60,7 @@ export const SbInteriorPage = ({ blok, slug }: SbInteriorPageProps) => {
     headerStyle,
     headerLogo,
     headerImage,
-    headerBackgroundColor = 'palo-alto-dark',
+    headerBackgroundColor,
     headerSpacingBottom,
     visibleVertical,
     localHeader,

--- a/components/Storyblok/SbLandingPage.tsx
+++ b/components/Storyblok/SbLandingPage.tsx
@@ -1,36 +1,53 @@
 import { type SbBlokData } from '@storyblok/react/rsc';
 import { storyblokEditable } from '@storyblok/react/rsc';
-import { IconCardSection, type IconCardSectionProps } from '@/components/Storyblok/partials/IconCardSection';
+import { IconCardSection } from '@/components/Storyblok/partials/IconCardSection';
 import { CreateBloks } from '@/components/CreateBloks';
-import { Footer, type FooterProps } from '@/components/Storyblok/partials/Footer';
+import { Footer } from '@/components/Storyblok/partials/Footer';
 
-type SbLandingPageProps = IconCardSectionProps & FooterProps & {
+type SbLandingPageProps = {
   blok: SbBlokData & {
     localHeader: SbBlokData[];
     alertPicker: SbBlokData[];
     heroSection: SbBlokData[];
     sections: SbBlokData[];
+    iconCardHeading?: string;
+    iconCards?: SbBlokData[];
+    localFooter?: SbBlokData[];
+    globalFooter?: SbBlokData[];
   };
   slug?: string;
 };
 
-export const SbLandingPage = (props: SbLandingPageProps) => (
-  <div {...storyblokEditable(props.blok)} className="ood-landing-page bg-fog-light">
-    <CreateBloks blokSection={props.blok.alertPicker} />
-    <CreateBloks blokSection={props.blok.localHeader} slug={props.slug} />
-    <main id="main-content" className="ood-landing-page__main">
-      <article className="bg-fog-light">
-        <header className="ood-landing-page__main-header">
-          <CreateBloks blokSection={props.blok.heroSection} />
-        </header>
-        <section className="ood-landing-page__main-body">
-          <CreateBloks blokSection={props.blok.sections} />
-        </section>
-      </article>
-      <footer className="ood-landing-page__main-footer">
-        <IconCardSection {...props} />
-      </footer>
-    </main>
-    <Footer {...props} />
-  </div>
-);
+export const SbLandingPage = ({ blok, slug }: SbLandingPageProps) => {
+  const {
+    localHeader,
+    alertPicker,
+    heroSection,
+    sections,
+    iconCardHeading,
+    iconCards,
+    localFooter,
+    globalFooter,
+  } = blok;
+
+  return (
+    <div {...storyblokEditable(blok)} className="ood-landing-page bg-fog-light">
+      <CreateBloks blokSection={alertPicker} />
+      <CreateBloks blokSection={localHeader} slug={slug} />
+      <main id="main-content" className="ood-landing-page__main">
+        <article className="bg-fog-light">
+          <header className="ood-landing-page__main-header">
+            <CreateBloks blokSection={heroSection} />
+          </header>
+          <section className="ood-landing-page__main-body">
+            <CreateBloks blokSection={sections} />
+          </section>
+        </article>
+        <footer className="ood-landing-page__main-footer">
+          <IconCardSection iconCards={iconCards} iconCardHeading={iconCardHeading} />
+        </footer>
+      </main>
+      <Footer localFooter={localFooter} globalFooter={globalFooter} />
+    </div>
+  );
+};

--- a/components/Storyblok/SbMegaMenu/SbMegaMenu.styles.ts
+++ b/components/Storyblok/SbMegaMenu/SbMegaMenu.styles.ts
@@ -1,5 +1,5 @@
 import { cnb } from 'cnbuilder';
-import { type DarkBgColorsType, darkBgColors } from '@/utilities/datasource';
+import { type DarkBgColorType, darkBgColors } from '@/utilities/datasource';
 
 export const innerShadow = 'absolute top-0 w-full h-15 bg-gradient-to-b from-black/10';
 
@@ -53,7 +53,7 @@ export const linkGroupItem = 'mb-20 last:mb-0';
 /**
  * Mega menu card
  */
-export const cardRoot = (backgroundColor: DarkBgColorsType = 'digital-red') => cnb(
+export const cardRoot = (backgroundColor: DarkBgColorType = 'digital-red') => cnb(
   'relative group',
   darkBgColors[backgroundColor],
 );

--- a/components/Storyblok/SbMegaMenu/SbMegaMenuCard.tsx
+++ b/components/Storyblok/SbMegaMenu/SbMegaMenuCard.tsx
@@ -3,13 +3,13 @@ import { AspectRatioImage } from '@/components/Image';
 import { SbLink } from '@/components/Storyblok/partials/SbLink';
 import { Heading, Paragraph } from '@/components/Typography';
 import { type SbImageType, type SbLinkType } from '@/components/Storyblok/Storyblok.types';
-import { type DarkBgColorsType } from '@/utilities/datasource';
+import { type DarkBgColorType } from '@/utilities/datasource';
 import * as styles from './SbMegaMenu.styles';
 
 export type SbMegaMenuCardProps = {
   blok: SbBlokData & {
     image?: SbImageType;
-    backgroundColor?: DarkBgColorsType
+    backgroundColor?: DarkBgColorType
     headline?: string;
     ctaText?: string;
     link?: SbLinkType;

--- a/components/Storyblok/SbRowThreeColumns.tsx
+++ b/components/Storyblok/SbRowThreeColumns.tsx
@@ -1,0 +1,7 @@
+export const SbRowThreeColumns = () => {
+  return (
+    <div className="bg-sky-dark rs-p-2">
+      <h2 className="text-white type-2">Row 3 Columns</h2>
+    </div>
+  );
+};

--- a/components/Storyblok/SbRowTwoColumns.tsx
+++ b/components/Storyblok/SbRowTwoColumns.tsx
@@ -1,0 +1,7 @@
+export const SbRowTwoColumns = () => {
+  return (
+    <div className="bg-sky-dark rs-p-2">
+      <h2 className="text-white type-2">Row 2 Columns</h2>
+    </div>
+  );
+};

--- a/components/Storyblok/SbStoryImage.tsx
+++ b/components/Storyblok/SbStoryImage.tsx
@@ -3,7 +3,7 @@ import { type StoryblokRichtext } from 'storyblok-rich-text-react-renderer';
 import { StoryImage, type StoryImageWidthType, type VisibleVerticalType } from '@/components/Image';
 import { RichText } from '@/components/RichText';
 import { type TextAlignType } from '@/components/Typography';
-import { type LightPageBgColorsType, type PaddingType } from '@/utilities/datasource';
+import { type LightPageBgColorType, type PaddingType } from '@/utilities/datasource';
 import { hasRichText } from '@/utilities/hasRichText';
 import { type SbImageType } from '@/components/Storyblok/Storyblok.types';
 
@@ -16,7 +16,7 @@ type SbStoryImageProps = {
     caption?: StoryblokRichtext;
     captionAlign?: TextAlignType;
     isCard?: boolean;
-    backgroundColor?: LightPageBgColorsType;
+    backgroundColor?: LightPageBgColorType;
     spacingTop?: PaddingType;
     spacingBottom?: PaddingType;
   };

--- a/components/Storyblok/SbStoryOverviewPage.tsx
+++ b/components/Storyblok/SbStoryOverviewPage.tsx
@@ -4,13 +4,13 @@ import { CreateBloks } from '@/components/CreateBloks';
 import { Footer } from '@/components/Storyblok/partials/Footer';
 import { HeaderNoImage } from '@/components/Storyblok/PageHeader/HeaderNoImage';
 import { IconCardSection } from '@/components/Storyblok/partials/IconCardSection';
-import { type DarkBgColorsType } from '@/utilities/datasource';
+import { type DarkBgColorType } from '@/utilities/datasource';
 
 type SbStoryOverviewPageProps = {
   blok: SbBlokData & {
     title?: string;
     intro?: StoryblokRichtext;
-    headerBackgroundColor?: DarkBgColorsType;
+    headerBackgroundColor?: DarkBgColorType;
     localHeader: SbBlokData[];
     alertPicker: SbBlokData[];
     stories: SbBlokData[];

--- a/components/Storyblok/SbSupportPage.tsx
+++ b/components/Storyblok/SbSupportPage.tsx
@@ -10,14 +10,14 @@ import { Footer } from '@/components/Storyblok/partials/Footer';
 import { Grid } from '@/components/Grid';
 import { IconCardSection } from '@/components/Storyblok/partials/IconCardSection';
 import { Heading, SrOnlyText } from '@/components/Typography';
-import { type DarkBgColorsType } from '@/utilities/datasource';
+import { type DarkBgColorType } from '@/utilities/datasource';
 
 
 export type SbSupportPageProps = {
   blok: SbBlokData & {
     title?: string;
     intro?: StoryblokRichtext;
-    headerBackgroundColor?: DarkBgColorsType;
+    headerBackgroundColor?: DarkBgColorType;
     localHeader: SbBlokData[];
     alertPicker: SbBlokData[];
     bodyTitle: string;

--- a/components/Storyblok/Storyblok.types.ts
+++ b/components/Storyblok/Storyblok.types.ts
@@ -58,6 +58,13 @@ export type SbLinkType =
       [k: string]: unknown;
     };
 
+// Storyblok plugin Fontawesome Selector
+export type SbFontawesomeSelectorType = {
+  _uid: string;
+  icon?: string;
+  type?: 'fas' | 'far'
+};
+
 /**
  * Reusable types for custom Storyblok components
  */

--- a/components/Storyblok/partials/IconCardSection.tsx
+++ b/components/Storyblok/partials/IconCardSection.tsx
@@ -1,6 +1,7 @@
 import { type SbBlokData } from '@storyblok/react/rsc';
 import { CreateBloks } from '@/components/CreateBloks';
 import { Container } from '@/components/Container';
+import { FlexBox } from '@/components/FlexBox';
 import { Heading } from '@/components/Typography';
 import { getNumBloks } from '@/utilities/getNumBloks';
 
@@ -20,11 +21,11 @@ export const IconCardSection = ({ iconCards, iconCardHeading }: IconCardSectionP
   }
 
   return (
-    <section>
+    <Container as="section" bgColor="black-10" py={6}>
       <Heading srOnly>{iconCardHeading || 'Links to more information'}</Heading>
-      <Container className={`flex ood-icon-card-section__container su-align-items-stretch su-flex-${numCards}-col`}>
+      <FlexBox alignItems="stretch" className={`grid-gap flex-col lg:flex-row ood-icon-card-section__container su-flex-${numCards}-col`}>
         <CreateBloks blokSection={iconCards} />
-      </Container>
-    </section>
+      </FlexBox>
+    </Container>
   );
 };

--- a/components/Storyblok/partials/IconCardSection.tsx
+++ b/components/Storyblok/partials/IconCardSection.tsx
@@ -11,7 +11,7 @@ export type IconCardSectionProps = {
 }
 
 /*
- * The Icon Card Section component is referenced by the Interior Page, Landing Page, Story page, and Support page types.
+ * The Icon Card Section component is referenced by all page types - Interior, Landing, Story, Story Overview, Support, Campaign
  */
 export const IconCardSection = ({ iconCards, iconCardHeading }: IconCardSectionProps) => {
   const numCards = getNumBloks(iconCards);
@@ -21,9 +21,9 @@ export const IconCardSection = ({ iconCards, iconCardHeading }: IconCardSectionP
   }
 
   return (
-    <Container as="section" bgColor="black-10" py={6}>
+    <Container as="section" bgColor="black-10" py={6} className="print:hidden grow-0">
       <Heading srOnly>{iconCardHeading || 'Links to more information'}</Heading>
-      <FlexBox alignItems="stretch" className={`grid-gap flex-col lg:flex-row ood-icon-card-section__container su-flex-${numCards}-col`}>
+      <FlexBox alignItems="stretch" className="grid-gap flex-col lg:flex-row">
         <CreateBloks blokSection={iconCards} />
       </FlexBox>
     </Container>

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,10 @@
       "name": "ood_giving_site",
       "version": "5.0.0",
       "dependencies": {
-        "@fortawesome/fontawesome-free": "^6.7.2",
+        "@fortawesome/fontawesome-svg-core": "^6.7.2",
+        "@fortawesome/free-regular-svg-icons": "^6.7.2",
+        "@fortawesome/free-solid-svg-icons": "^6.7.2",
+        "@fortawesome/react-fontawesome": "^0.2.2",
         "@headlessui/react": "^2.2.4",
         "@heroicons/react": "^2.2.0",
         "@netlify/functions": "^3.0.4",
@@ -534,13 +537,62 @@
       "integrity": "sha512-MDWhGtE+eHw5JW7lq4qhc5yRLS11ERl1c7Z6Xd0a58DozHES6EnNNwUWbMiG4J9Cgj053Bhk8zvlhFYKVhULwg==",
       "license": "MIT"
     },
-    "node_modules/@fortawesome/fontawesome-free": {
+    "node_modules/@fortawesome/fontawesome-common-types": {
       "version": "6.7.2",
-      "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-free/-/fontawesome-free-6.7.2.tgz",
-      "integrity": "sha512-JUOtgFW6k9u4Y+xeIaEiLr3+cjoUPiAuLXoyKOJSia6Duzb7pq+A76P9ZdPDoAoxHdHzq6gE9/jKBGXlZT8FbA==",
-      "license": "(CC-BY-4.0 AND OFL-1.1 AND MIT)",
+      "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-common-types/-/fontawesome-common-types-6.7.2.tgz",
+      "integrity": "sha512-Zs+YeHUC5fkt7Mg1l6XTniei3k4bwG/yo3iFUtZWd/pMx9g3fdvkSK9E0FOC+++phXOka78uJcYb8JaFkW52Xg==",
+      "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/@fortawesome/fontawesome-svg-core": {
+      "version": "6.7.2",
+      "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-svg-core/-/fontawesome-svg-core-6.7.2.tgz",
+      "integrity": "sha512-yxtOBWDrdi5DD5o1pmVdq3WMCvnobT0LU6R8RyyVXPvFRd2o79/0NCuQoCjNTeZz9EzA9xS3JxNWfv54RIHFEA==",
+      "license": "MIT",
+      "dependencies": {
+        "@fortawesome/fontawesome-common-types": "6.7.2"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@fortawesome/free-regular-svg-icons": {
+      "version": "6.7.2",
+      "resolved": "https://registry.npmjs.org/@fortawesome/free-regular-svg-icons/-/free-regular-svg-icons-6.7.2.tgz",
+      "integrity": "sha512-7Z/ur0gvCMW8G93dXIQOkQqHo2M5HLhYrRVC0//fakJXxcF1VmMPsxnG6Ee8qEylA8b8Q3peQXWMNZ62lYF28g==",
+      "license": "(CC-BY-4.0 AND MIT)",
+      "dependencies": {
+        "@fortawesome/fontawesome-common-types": "6.7.2"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@fortawesome/free-solid-svg-icons": {
+      "version": "6.7.2",
+      "resolved": "https://registry.npmjs.org/@fortawesome/free-solid-svg-icons/-/free-solid-svg-icons-6.7.2.tgz",
+      "integrity": "sha512-GsBrnOzU8uj0LECDfD5zomZJIjrPhIlWU82AHwa2s40FKH+kcxQaBvBo3Z4TxyZHIyX8XTDxsyA33/Vx9eFuQA==",
+      "license": "(CC-BY-4.0 AND MIT)",
+      "dependencies": {
+        "@fortawesome/fontawesome-common-types": "6.7.2"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@fortawesome/react-fontawesome": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/@fortawesome/react-fontawesome/-/react-fontawesome-0.2.2.tgz",
+      "integrity": "sha512-EnkrprPNqI6SXJl//m29hpaNzOp1bruISWaOiRtkMi/xSvHJlzc2j2JAYS7egxt/EbjSNV/k6Xy0AQI6vB2+1g==",
+      "license": "MIT",
+      "dependencies": {
+        "prop-types": "^15.8.1"
+      },
+      "peerDependencies": {
+        "@fortawesome/fontawesome-svg-core": "~1 || ~6",
+        "react": ">=16.3"
       }
     },
     "node_modules/@headlessui/react": {
@@ -6325,7 +6377,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
       "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/js-yaml": {
@@ -6721,7 +6772,6 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
       "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "js-tokens": "^3.0.0 || ^4.0.0"
@@ -23352,7 +23402,6 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
       "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
-      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -24036,7 +24085,6 @@
       "version": "15.8.1",
       "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
       "integrity": "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "loose-envify": "^1.4.0",
@@ -24196,7 +24244,6 @@
       "version": "16.13.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/read-cache": {

--- a/package.json
+++ b/package.json
@@ -31,7 +31,10 @@
     "tsc": "tsc"
   },
   "dependencies": {
-    "@fortawesome/fontawesome-free": "^6.7.2",
+    "@fortawesome/fontawesome-svg-core": "^6.7.2",
+    "@fortawesome/free-regular-svg-icons": "^6.7.2",
+    "@fortawesome/free-solid-svg-icons": "^6.7.2",
+    "@fortawesome/react-fontawesome": "^0.2.2",
     "@headlessui/react": "^2.2.4",
     "@heroicons/react": "^2.2.0",
     "@netlify/functions": "^3.0.4",

--- a/utilities/datasource.ts
+++ b/utilities/datasource.ts
@@ -4,7 +4,7 @@ export const lightPageBgColors = {
   white: 'bg-white',
   'fog-light': 'bg-fog-light',
 };
-export type LightPageBgColorsType = keyof typeof lightPageBgColors;
+export type LightPageBgColorType = keyof typeof lightPageBgColors;
 
 export const darkBgColors = {
   'bay-dark': 'bg-bay-dark',
@@ -28,7 +28,30 @@ export const darkBgColors = {
   'plum': 'bg-plum',
   'brick': 'bg-brick',
 };
-export type DarkBgColorsType = keyof typeof darkBgColors;
+export type DarkBgColorType = keyof typeof darkBgColors;
+
+export const cardBgColors = {
+  'white': 'bg-white',
+  'bay-dark': 'bg-bay-dark',
+  'palo-alto': 'bg-palo-alto',
+  'palo-alto-dark': 'bg-palo-alto-dark',
+  'palo-verde': 'bg-palo-verde',
+  'palo-verde-dark': 'bg-palo-verde-dark',
+  'lagunita': 'bg-lagunita',
+  'plum': 'bg-plum',
+  'lagunita-dark': 'bg-lagunita-dark',
+  'sky-dark': 'bg-sky-dark',
+  'digital-red': 'bg-digital-red',
+  'cardinal-red': 'bg-cardinal-red',
+  'brick': 'bg-brick',
+  'cardinal-dark-to-spirited-dark': 'bg-gradient-to-tr from-cardinal-dark to-spirited-dark',
+  'plum-to-digital-red': 'bg-gradient-to-tr from-plum to-digital-red',
+  'plum-to-spirited-dark': 'bg-gradient-to-tr from-plum to-spirited-dark',
+  'palo-alto-dark-to-palo-verde-dark': 'bg-gradient-to-tr from-palo-alto-dark to-palo-verde-dark',
+  'sky-dark-to-olive-dark': 'bg-gradient-to-tr from-sky-dark to-olive-dark',
+  'sky-dark-to-bay-dark': 'bg-gradient-to-tr from-sky-dark to-bay-dark',
+};
+export type CardBgColorType = keyof typeof cardBgColors;
 
 export const paddingTops = {
   none: '',

--- a/utilities/storyblok.tsx
+++ b/utilities/storyblok.tsx
@@ -37,6 +37,9 @@ import {
 } from '@/components/Storyblok/SbMegaMenu';
 import { SbSection } from '@/components/Storyblok/SbSection';
 import { SbRowOneColumn } from '@/components/Storyblok/SbRowOneColumn';
+import { SbRowTwoColumns } from '@/components/Storyblok/SbRowTwoColumns';
+import { SbRowThreeColumns } from '@/components/Storyblok/SbRowThreeColumns';
+import { SbColumnGrid } from '@/components/Storyblok/SbColumnGrid';
 import { SbBasicCard } from '@/components/Storyblok/SbBasicCard';
 import { SbCtaGroup } from '@/components/Storyblok/SbCtaGroup';
 import { SbIconCard } from '@/components/Storyblok/SbIconCard';
@@ -81,7 +84,10 @@ export const components = {
   oodMegaMenuLinkGroup: SbMegaMenuLinkGroup,
   oodMegaMenuCard: SbMegaMenuCard,
   // Layout
+  columnGrid: SbColumnGrid,
   rowOneColumn: SbRowOneColumn,
+  rowTwoColumns: SbRowTwoColumns,
+  rowThreeColumns: SbRowThreeColumns,
   section: SbSection,
   singleColumnContent: SbSingleColumnContent,
   // Media


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- Icon Card and Icon Card Section components
- Install FontAwesome and add FAIcon component
- Add active link style for nested content menu

# Review By (Date)
- Soon

# Criticality
- 5

# Review Tasks

## Setup tasks and/or behavior to test

NOTE: I haven't added the IconCardSection to Campaign pages - will deal with that when that page type is worked on
1. Click around the links on the site to see the Icon Cards above the local footer
2. Check for responsive
3. Compare them to live site
4. See below callout for active nested content menu links


# Associated Issues and/or People
- DS-1436 DS-1494
