### PR TITLE
DS-1468 | Section; RowOneColumn updates

### DIFF
--- a/components/Cta/CtaGroup.tsx
+++ b/components/Cta/CtaGroup.tsx
@@ -17,6 +17,7 @@ export const CtaGroup = ({
     <FlexBox
       {...props}
       as="ul"
+      mb="1em" // Gatsby build adds a 1em margin-bottom to each cta inside a CTA group
       direction={display === 'inline-block' ? 'row' : 'col'}
       wrap={display === 'inline-block' ? 'wrap' : 'nowrap'}
       justifyContent={display === 'inline-block' ? 'center' : 'start'}

--- a/components/IconCard/IconCard.styles.ts
+++ b/components/IconCard/IconCard.styles.ts
@@ -10,7 +10,7 @@ export type ContentAlignType = keyof typeof align;
 
 // TODO DS-1433: Container query for smaller x padding when card is narrow
 export const root = (backgroundColor: CardBgColorType) => cnb(
-  'relative print:hidden break-words mx-auto w-full sm:w-3/4 lg:w-full rs-px-3 shadow-md focus-within:shadow-lg hover:shadow-lg transition-shadow',
+  'relative print:hidden break-words mx-auto w-full sm:w-3/4 lg:w-full rs-px-3 border border-black-10 shadow-md focus-within:shadow-lg hover:shadow-lg transition-shadow',
   cardBgColors[backgroundColor || 'white'],
   backgroundColor === 'white' ? 'text-black' : 'text-white',
 );

--- a/components/IconCard/IconCard.styles.ts
+++ b/components/IconCard/IconCard.styles.ts
@@ -10,7 +10,7 @@ export type ContentAlignType = keyof typeof align;
 
 // TODO DS-1433: Container query for smaller x padding when card is narrow
 export const root = (backgroundColor: CardBgColorType) => cnb(
-  'relative print:hidden break-words mx-auto sm:w-3/4 rs-px-3 w-full shadow-md focus-within:shadow-lg hover:shadow-lg transition-shadow',
+  'relative print:hidden break-words mx-auto w-full sm:w-3/4 lg:w-full rs-px-3 shadow-md focus-within:shadow-lg hover:shadow-lg transition-shadow',
   cardBgColors[backgroundColor || 'white'],
   backgroundColor === 'white' ? 'text-black' : 'text-white',
 );

--- a/components/RichText/RichText.tsx
+++ b/components/RichText/RichText.tsx
@@ -6,6 +6,7 @@ import {
   MARK_STYLED,
   MARK_LINK,
   MARK_STRIKE,
+  MARK_TEXT_STYLE,
   NODE_HEADING,
   NODE_PARAGRAPH,
   NODE_IMAGE,
@@ -83,6 +84,7 @@ export const RichText = ({
       [MARK_BOLD]: (children) => <strong>{children}</strong>,
       [MARK_ITALIC]: (children) => <em>{children}</em>,
       [MARK_STRIKE]: (children) => <del>{children}</del>,
+      [MARK_TEXT_STYLE]: (children, { color }) => <>{children}</>,
       [MARK_LINK]: (children, props) => {
         const {
           href,

--- a/components/RichText/RichText.tsx
+++ b/components/RichText/RichText.tsx
@@ -31,7 +31,7 @@ import { getProcessedImage } from '@/utilities/getProcessedImage';
  * "default" means using the inherited body font size as the base font size
  * "card" means using the card-paragraph style as the base font size (smaller than default)
  */
-export type RichTextBaseFontSizeType = 'default' | 'card' | 'base23';
+export type RichTextBaseFontSizeType = 'default' | 'card' | 'base23' | 'intro';
 
 export type RichTextProps = {
   wysiwyg: StoryblokRichtext;

--- a/components/Row/Row.styles.ts
+++ b/components/Row/Row.styles.ts
@@ -5,6 +5,26 @@ export type ContentALignmentType = 'start' | 'center' | 'end' | 'stretch';
 
 export const root = (contentAlignment: ContentALignmentType) => contentAlignment === 'stretch' && '*:*:h-full';
 
+export const rowAligns = {
+  'su-mx-auto': 'mx-auto', // center
+  'su-ml-none': '', // left
+  'su-mr-none su-ml-auto': 'ml-auto', // right
+};
+export type RowAlignType = keyof typeof rowAligns;
+
+/**
+ * Row with 1 column
+ */
+export const rowOneColumnWidths = {
+  'flex-12-of-12': 'w-full', // 12 of 12 columns
+  'flex-lg-10-of-12': 'lg:w-10/12', // 10 of 12 columns at LG
+  'flex-lg-9-of-12': 'lg:w-9/12', // 9 of 12 columns at LG
+  'flex-lg-10-of-12 flex-xl-8-of-12': 'lg:w-10/12 xl:w-8/12', // 8 of 12 columns at XL
+  'flex-md-10-of-12 flex-lg-8-of-12 flex-xl-6-of-12': 'md:w-10/12 lg:w-8/12 xl:w-6/12', // 6 of 12 columns at XL
+  'flex-md-8-of-12 flex-lg-6-of-12 flex-xl-4-of-12': 'md:w-8/12 lg:w-6/12 xl:w-4/12', // 4 of 12 columns at XL
+};
+export type RowOneColumnWidthType = keyof typeof rowOneColumnWidths;
+
 /**
  * Row with 2 columns
  */
@@ -12,19 +32,12 @@ export type WidthRatioType = '1-to-1' | '1-to-2' | '2-to-1';
 
 // TODO: Think about whether to finetune old flex width classes at the end
 // https://stanford.atlassian.net/browse/DS-1433
-export const rowWidths = {
+export const rowTwoColumnWidths = {
   'full': 'w-full',
   'flex-xl-10-of-12': 'xl:w-10/12',
   'flex-lg-10-of-12 flex-xl-8-of-12': 'lg:w-10/12 xl:w-8/12',
 };
-export type RowWidthType = keyof typeof rowWidths;
-
-export const rowAligns = {
-  'su-mx-auto': 'mx-auto', // center
-  'su-ml-none': '', // left
-  'su-mr-none su-ml-auto': 'ml-auto', // right
-};
-export type RowAlignType = keyof typeof rowAligns;
+export type RowTwoColumnWidthType = keyof typeof rowTwoColumnWidths;
 
 export const colOne = (widthRatio: WidthRatioType, oneColumnMd: boolean) => cnb({
   'md:col-span-3': (widthRatio === '1-to-1' || !widthRatio) && !oneColumnMd,

--- a/components/Row/Row.styles.ts
+++ b/components/Row/Row.styles.ts
@@ -12,6 +12,9 @@ export const rowAligns = {
 };
 export type RowAlignType = keyof typeof rowAligns;
 
+// TODO: Think about whether to finetune old flex width classes at the end
+// https://stanford.atlassian.net/browse/DS-1433
+
 /**
  * Row with 1 column
  */
@@ -30,8 +33,6 @@ export type RowOneColumnWidthType = keyof typeof rowOneColumnWidths;
  */
 export type WidthRatioType = '1-to-1' | '1-to-2' | '2-to-1';
 
-// TODO: Think about whether to finetune old flex width classes at the end
-// https://stanford.atlassian.net/browse/DS-1433
 export const rowTwoColumnWidths = {
   'full': 'w-full',
   'flex-xl-10-of-12': 'xl:w-10/12',

--- a/components/Row/RowOneColumn.tsx
+++ b/components/Row/RowOneColumn.tsx
@@ -1,7 +1,27 @@
-type RowOneColumnProps = React.HTMLAttributes<HTMLDivElement>;
+import { cnb } from 'cnbuilder';
+import { Container, type ContainerProps } from '@/components/Container';
+import * as styles from './Row.styles';
 
-export const RowOneColumn = ({ children, ...props }: RowOneColumnProps) => {
+type RowOneColumnProps = ContainerProps & {
+  rowWidth?: styles.RowOneColumnWidthType;
+  // Horizontal alignment of the whole row if rowWidth is not 'full'
+  align?: styles.RowAlignType;
+};
+
+export const RowOneColumn = ({
+  rowWidth = 'flex-lg-10-of-12 flex-xl-8-of-12',
+  align = 'su-mx-auto',
+  mb,
+  children,
+  ...props
+}: RowOneColumnProps) => {
   return (
-    <div {...props}>{children}</div>
+    <Container
+      mb={mb}
+      className={cnb(styles.rowOneColumnWidths[rowWidth], styles.rowAligns[align])}
+      {...props}
+    >
+      {children}
+    </Container>
   );
 };

--- a/components/Row/RowTwoColumns.tsx
+++ b/components/Row/RowTwoColumns.tsx
@@ -26,13 +26,11 @@ export const RowTwoColumns = ({
   mb,
   ...props
 }: RowTwoColumnProps) => {
-  const isColWidthSame = widthRatio === '1-to-1' || !widthRatio;
-
   return (
     <Grid
       gap="card"
-      md={!isColWidthSame ? 2 : 3}
-      lg={oneColumnMd && !isColWidthSame ? 3 : undefined}
+      md={oneColumnMd ? undefined : 6}
+      lg={oneColumnMd ? 6 : undefined}
       mb={mb}
       alignItems={contentAlignment}
       className={cnb(styles.root(contentAlignment), styles.rowTwoColumnWidths[rowWidth], styles.rowAligns[align])}

--- a/components/Row/RowTwoColumns.tsx
+++ b/components/Row/RowTwoColumns.tsx
@@ -5,7 +5,7 @@ import * as styles from './Row.styles';
 type RowTwoColumnProps = GridProps & {
   columnOneContent?: React.ReactNode;
   columnTwoContent?: React.ReactNode;
-  rowWidth?: styles.RowWidthType;
+  rowWidth?: styles.RowTwoColumnWidthType;
   widthRatio?: styles.WidthRatioType;
   // If true, have all content stacked vertically at MD breakpoint
   oneColumnMd?: boolean;
@@ -35,7 +35,7 @@ export const RowTwoColumns = ({
       lg={oneColumnMd && !isColWidthSame ? 3 : undefined}
       mb={mb}
       alignItems={contentAlignment}
-      className={cnb(styles.root(contentAlignment), styles.rowWidths[rowWidth], styles.rowAligns[align])}
+      className={cnb(styles.root(contentAlignment), styles.rowTwoColumnWidths[rowWidth], styles.rowAligns[align])}
       {...props}
     >
       <div className={styles.colOne(widthRatio, oneColumnMd)}>

--- a/components/Section/Section.styles.ts
+++ b/components/Section/Section.styles.ts
@@ -1,0 +1,13 @@
+export const sectionContentWidths = {
+  'edge-to-edge': 'w-full',
+  'centered-container': 'w-full',
+  'flex-xl-10-of-12': '',
+  'flex-lg-10-of-12 flex-xl-8-of-12': '',
+};
+export type SectionContentWidthType = keyof typeof sectionContentWidths;
+
+export const titleStyles = {
+  'ood-has-tab-before': '',
+  'su-italic': 'font-italic',
+};
+export type TitleStyleType = keyof typeof titleStyles;

--- a/components/Section/Section.styles.ts
+++ b/components/Section/Section.styles.ts
@@ -1,11 +1,13 @@
 import { cnb } from 'cnbuilder';
 import { type DarkBeforeColorType, darkBeforeColors } from '@/utilities/datasource';
 
+// TODO: Think about whether to finetune old flex width classes at the end
+// https://stanford.atlassian.net/browse/DS-1433
 export const sectionContentWidths = {
   'edge-to-edge': 'w-full',
   'centered-container': 'w-full',
-  'flex-xl-10-of-12': '',
-  'flex-lg-10-of-12 flex-xl-8-of-12': '',
+  'flex-xl-10-of-12': 'xl:w-10/12',
+  'flex-lg-10-of-12 flex-xl-8-of-12': 'lg:w-10/12 xl:w-8/12',
 };
 export type SectionContentWidthType = keyof typeof sectionContentWidths;
 
@@ -30,7 +32,10 @@ export const title = (titleStyle: TitleStyleType[], tabColor: DarkBeforeColorTyp
 };
 
 export const intro = (srOnlyHeader: boolean, isCenterAlignHeader: boolean) => cnb(
-  'mb-1em *:*:max-w-prose-wide text-pretty',
+  'mb-1em text-pretty',
   srOnlyHeader && 'sr-only',
-  isCenterAlignHeader && '*:*:mx-auto *:*:max-w-800',
+  // In Gatsby build, the intro width is 100% when left aligned, but I added max-w-prose-wide here for better readability
+  isCenterAlignHeader ? '*:*:mx-auto *:*:max-w-800' : '*:*:max-w-prose-wide',
 );
+
+export const content = (contentWidth: SectionContentWidthType) => sectionContentWidths[contentWidth || 'centered-container'];

--- a/components/Section/Section.styles.ts
+++ b/components/Section/Section.styles.ts
@@ -11,6 +11,8 @@ export const sectionContentWidths = {
 };
 export type SectionContentWidthType = keyof typeof sectionContentWidths;
 
+export const header = (srOnlyHeader: boolean) => srOnlyHeader && 'sr-only';
+
 export const titleStyles = {
   'ood-has-tab-before': 'before:block before:mb-03em before:content-[""] before:h-10 before:w-80',
   'su-italic': 'italic',

--- a/components/Section/Section.styles.ts
+++ b/components/Section/Section.styles.ts
@@ -11,13 +11,26 @@ export type SectionContentWidthType = keyof typeof sectionContentWidths;
 
 export const titleStyles = {
   'ood-has-tab-before': 'before:block before:mb-03em before:content-[""] before:h-10 before:w-80',
-  'su-italic': 'font-italic',
+  'su-italic': 'italic',
 };
 export type TitleStyleType = keyof typeof titleStyles;
 
-export const title = (titleStyle: TitleStyleType[], tabColor: DarkBeforeColorType) => cnb('', {
-  [titleStyles['ood-has-tab-before']]: titleStyle.includes('ood-has-tab-before'),
-  [titleStyles['su-italic']]: titleStyle.includes('su-italic'),
-},
-  titleStyle.includes('ood-has-tab-before') ? darkBeforeColors[tabColor || 'cardinal-red'] : '',
+export const title = (titleStyle: TitleStyleType[], tabColor: DarkBeforeColorType, isCenterAlignHeader: boolean) => {
+  const styleSet = new Set(titleStyle);
+  const hasTabBefore = styleSet.has('ood-has-tab-before');
+  const isItalic = styleSet.has('su-italic');
+
+  return cnb('w-fit max-w-1200', {
+    [titleStyles['ood-has-tab-before']]: hasTabBefore,
+    [titleStyles['su-italic']]: isItalic,
+  },
+    hasTabBefore && darkBeforeColors[tabColor || 'cardinal-red'],
+    isCenterAlignHeader && 'mx-auto',
+  );
+};
+
+export const intro = (srOnlyHeader: boolean, isCenterAlignHeader: boolean) => cnb(
+  'mb-1em *:*:max-w-prose-wide text-pretty',
+  srOnlyHeader && 'sr-only',
+  isCenterAlignHeader && '*:*:mx-auto *:*:max-w-800',
 );

--- a/components/Section/Section.styles.ts
+++ b/components/Section/Section.styles.ts
@@ -1,3 +1,6 @@
+import { cnb } from 'cnbuilder';
+import { type DarkBeforeColorType, darkBeforeColors } from '@/utilities/datasource';
+
 export const sectionContentWidths = {
   'edge-to-edge': 'w-full',
   'centered-container': 'w-full',
@@ -7,7 +10,14 @@ export const sectionContentWidths = {
 export type SectionContentWidthType = keyof typeof sectionContentWidths;
 
 export const titleStyles = {
-  'ood-has-tab-before': '',
+  'ood-has-tab-before': 'before:block before:mb-03em before:content-[""] before:h-10 before:w-80',
   'su-italic': 'font-italic',
 };
 export type TitleStyleType = keyof typeof titleStyles;
+
+export const title = (titleStyle: TitleStyleType[], tabColor: DarkBeforeColorType) => cnb('', {
+  [titleStyles['ood-has-tab-before']]: titleStyle.includes('ood-has-tab-before'),
+  [titleStyles['su-italic']]: titleStyle.includes('su-italic'),
+},
+  titleStyle.includes('ood-has-tab-before') ? darkBeforeColors[tabColor || 'cardinal-red'] : '',
+);

--- a/components/Section/Section.styles.ts
+++ b/components/Section/Section.styles.ts
@@ -40,4 +40,4 @@ export const intro = (srOnlyHeader: boolean, isCenterAlignHeader: boolean) => cn
   isCenterAlignHeader ? '*:*:mx-auto *:*:max-w-800' : '*:*:max-w-prose-wide',
 );
 
-export const content = (contentWidth: SectionContentWidthType) => sectionContentWidths[contentWidth || 'centered-container'];
+export const content = (contentWidth: SectionContentWidthType) => cnb('mx-auto', sectionContentWidths[contentWidth || 'centered-container']);

--- a/components/Section/Section.tsx
+++ b/components/Section/Section.tsx
@@ -25,9 +25,9 @@ export const Section = ({
   intro,
   srOnlyHeader,
   isEdgeToEdgeHeader,
-  titleStyle = [],
+  titleStyle,
   tabColor = 'cardinal-red',
-  titleSize = 'f4',
+  titleSize = 4,
   headingLevel = 'h2',
   isCenterAlignHeader,
   isSansSemiboldTitle,
@@ -58,16 +58,20 @@ export const Section = ({
             <Heading
               as={headingLevel}
               srOnly={srOnlyHeader}
-              className={styles.title(titleStyle, tabColor)}
+              className={styles.title(titleStyle, tabColor, isCenterAlignHeader)}
               size={titleSize}
+              font={isSansSemiboldTitle ? 'sans' : 'serif'}
+              weight={isSansSemiboldTitle ? 'semibold' : 'bold'}
               align={isCenterAlignHeader ? 'center' : undefined}
+              mb={3}
             >
               {title}
             </Heading>
           )}
-          {intro && <div className={srOnlyHeader && 'sr-only'}>{intro}</div>}
+          {intro && <div className={styles.intro(srOnlyHeader, isCenterAlignHeader)}>{intro}</div>}
         </Container>
       )}
+      {/* On the Gatsby build, if there is no header, a spacer 3 is added above the content so we honor that here */}
       <Container pt={!hasHeader ? 3 : undefined}>
         {children}
       </Container>

--- a/components/Section/Section.tsx
+++ b/components/Section/Section.tsx
@@ -70,11 +70,8 @@ export const Section = ({
           {intro && <div className={styles.intro(srOnlyHeader, isCenterAlignHeader)}>{intro}</div>}
         </Container>
       )}
-      <Container
-        width={contentWidth === 'edge-to-edge' ? 'full' : 'site'}
-        className={styles.content(contentWidth)}
-      >
-        {children}
+      <Container width={contentWidth === 'edge-to-edge' ? 'full' : 'site'}>
+        <div className={styles.content(contentWidth)}>{children}</div>
       </Container>
     </Container>
   );

--- a/components/Section/Section.tsx
+++ b/components/Section/Section.tsx
@@ -52,7 +52,7 @@ export const Section = ({
       pb={pb}
     >
       {hasHeader && (
-        <Container mb={3} as="header" width={isEdgeToEdgeHeader ? 'full' : 'site'} className={srOnlyHeader && 'sr-only'}>
+        <Container mb={3} as="header" width={isEdgeToEdgeHeader ? 'full' : 'site'} className={styles.header(srOnlyHeader)}>
           {title && (
             <Heading
               as={headingLevel}
@@ -72,8 +72,6 @@ export const Section = ({
       )}
       <Container
         width={contentWidth === 'edge-to-edge' ? 'full' : 'site'}
-        // In the Gatsby build, if there is no header, a spacer 3 is added above the content so we honor that here
-        pt={!hasHeader ? 3 : undefined}
         className={styles.content(contentWidth)}
       >
         {children}

--- a/components/Section/Section.tsx
+++ b/components/Section/Section.tsx
@@ -1,5 +1,6 @@
 import { Container, type ContainerProps } from '@/components/Container';
 import { Heading, type FontSizeType, type HeadingType } from '@/components/Typography';
+import { type DarkBeforeColorType } from '@/utilities/datasource';
 import * as styles from './Section.styles';
 
 type SectionProps = ContainerProps & {
@@ -9,7 +10,7 @@ type SectionProps = ContainerProps & {
   srOnlyHeader?: boolean;
   isEdgeToEdgeHeader?: boolean;
   titleStyle?: styles.TitleStyleType[];
-  tabColor?: string;
+  tabColor?: DarkBeforeColorType;
   titleSize?: FontSizeType;
   headingLevel?: HeadingType;
   // Campaign page only header options
@@ -25,7 +26,7 @@ export const Section = ({
   srOnlyHeader,
   isEdgeToEdgeHeader,
   titleStyle = [],
-  tabColor,
+  tabColor = 'cardinal-red',
   titleSize = 'f4',
   headingLevel = 'h2',
   isCenterAlignHeader,
@@ -43,6 +44,7 @@ export const Section = ({
   return (
     <Container
       {...props}
+      as={title ? 'section' : 'div'}
       id={id}
       width="full"
       // className={styles.container}
@@ -51,18 +53,19 @@ export const Section = ({
       pb={pb}
     >
       {hasHeader && (
-        <Container mb={3} as="header" width={isEdgeToEdgeHeader ? 'full' : 'site'}>
+        <Container mb={3} as="header" width={isEdgeToEdgeHeader ? 'full' : 'site'} className={srOnlyHeader && 'sr-only'}>
           {title && (
             <Heading
               as={headingLevel}
-              //className={styles.title(headerStyles)}
-              size={titleSize}
               srOnly={srOnlyHeader}
+              className={styles.title(titleStyle, tabColor)}
+              size={titleSize}
+              align={isCenterAlignHeader ? 'center' : undefined}
             >
               {title}
             </Heading>
           )}
-          {intro && <div>{intro}</div>}
+          {intro && <div className={srOnlyHeader && 'sr-only'}>{intro}</div>}
         </Container>
       )}
       <Container pt={!hasHeader ? 3 : undefined}>

--- a/components/Section/Section.tsx
+++ b/components/Section/Section.tsx
@@ -1,0 +1,73 @@
+import { Container, type ContainerProps } from '@/components/Container';
+import { Heading, type FontSizeType, type HeadingType } from '@/components/Typography';
+import * as styles from './Section.styles';
+
+type SectionProps = ContainerProps & {
+  // Header
+  title?: string;
+  intro?: React.ReactNode;
+  srOnlyHeader?: boolean;
+  isEdgeToEdgeHeader?: boolean;
+  titleStyle?: styles.TitleStyleType[];
+  tabColor?: string;
+  titleSize?: FontSizeType;
+  headingLevel?: HeadingType;
+  // Campaign page only header options
+  isCenterAlignHeader?: boolean;
+  isSansSemiboldTitle?: boolean;
+  // Content
+  contentWidth?: styles.SectionContentWidthType;
+};
+
+export const Section = ({
+  title,
+  intro,
+  srOnlyHeader,
+  isEdgeToEdgeHeader,
+  titleStyle = [],
+  tabColor,
+  titleSize = 'f4',
+  headingLevel = 'h2',
+  isCenterAlignHeader,
+  isSansSemiboldTitle,
+  children,
+  contentWidth = 'edge-to-edge',
+  id,
+  bgColor = 'white',
+  pt,
+  pb,
+  ...props
+}: SectionProps) => {
+  const hasHeader = !!title || !!intro;
+
+  return (
+    <Container
+      {...props}
+      id={id}
+      width="full"
+      // className={styles.container}
+      bgColor={bgColor}
+      pt={pt}
+      pb={pb}
+    >
+      {hasHeader && (
+        <Container mb={3} as="header" width={isEdgeToEdgeHeader ? 'full' : 'site'}>
+          {title && (
+            <Heading
+              as={headingLevel}
+              //className={styles.title(headerStyles)}
+              size={titleSize}
+              srOnly={srOnlyHeader}
+            >
+              {title}
+            </Heading>
+          )}
+          {intro && <div>{intro}</div>}
+        </Container>
+      )}
+      <Container pt={!hasHeader ? 3 : undefined}>
+        {children}
+      </Container>
+    </Container>
+  );
+};

--- a/components/Section/Section.tsx
+++ b/components/Section/Section.tsx
@@ -47,7 +47,6 @@ export const Section = ({
       as={title ? 'section' : 'div'}
       id={id}
       width="full"
-      // className={styles.container}
       bgColor={bgColor}
       pt={pt}
       pb={pb}
@@ -71,8 +70,12 @@ export const Section = ({
           {intro && <div className={styles.intro(srOnlyHeader, isCenterAlignHeader)}>{intro}</div>}
         </Container>
       )}
-      {/* On the Gatsby build, if there is no header, a spacer 3 is added above the content so we honor that here */}
-      <Container pt={!hasHeader ? 3 : undefined}>
+      <Container
+        width={contentWidth === 'edge-to-edge' ? 'full' : 'site'}
+        // In the Gatsby build, if there is no header, a spacer 3 is added above the content so we honor that here
+        pt={!hasHeader ? 3 : undefined}
+        className={styles.content(contentWidth)}
+      >
         {children}
       </Container>
     </Container>

--- a/components/Section/index.ts
+++ b/components/Section/index.ts
@@ -1,0 +1,2 @@
+export * from './Section';
+export * from './Section.styles';

--- a/components/Storyblok/PageHeader/HeaderNoImage.tsx
+++ b/components/Storyblok/PageHeader/HeaderNoImage.tsx
@@ -44,7 +44,7 @@ export const HeaderNoImage = ({
         <div className="relative bg-white w-full max-w-full -mt-[3em] md:-mt-[6em] rs-p-4 shadow-md">
           {hasRichText(intro) && (
             <div className="relative w-full xl:w-3/4 mx-auto">
-              <RichText wysiwyg={intro} className="md:text-center text-20 md:text-25 lg:text-29 [&_p]:text-pretty [&_p]:leading-cozy" />
+              <RichText wysiwyg={intro} baseFontSize="intro" className="md:text-center [&_p]:text-pretty [&_p]:leading-cozy" />
             </div>
           )}
         </div>

--- a/components/Storyblok/SbInteriorPage.tsx
+++ b/components/Storyblok/SbInteriorPage.tsx
@@ -142,7 +142,7 @@ export const SbInteriorPage = ({ blok, slug }: SbInteriorPageProps) => {
                   </Heading>
                 </Container>
               )}
-              <Grid pb={6} gap="default" lg={12} className="cc">
+              <Grid pb={6} lg={12} className="cc lg:grid-gap">
                 {/* Sidebar */}
                 {layout === 'left-sidebar' && (
                   <aside className="lg:col-span-4 xl:col-span-3 gap-y-20 md:gap-y-26 2xl:gap-y-27">

--- a/components/Storyblok/SbMegaMenu/SbMegaMenuLinkGroup.tsx
+++ b/components/Storyblok/SbMegaMenu/SbMegaMenuLinkGroup.tsx
@@ -30,7 +30,6 @@ export const SbMegaMenuLinkGroup = ({ blok }: SbMegaMenuLinkGroupProps) => {
               <CtaLink
                 sbLink={link}
                 variant="mega-menu-link-lvl2"
-                align="right"
                 icon={link.linktype === 'story' ? 'su-link--no-icon' : 'su-link--external'}
               >
                 {linkText}

--- a/components/Storyblok/SbRowOneColumn.tsx
+++ b/components/Storyblok/SbRowOneColumn.tsx
@@ -1,21 +1,30 @@
 import { storyblokEditable, type SbBlokData } from '@storyblok/react/rsc';
 import { CreateBloks } from '@/components/CreateBloks';
-import { RowOneColumn } from '@/components/Row';
+import { RowOneColumn, type RowOneColumnWidthType, type RowAlignType } from '@/components/Row';
 import { getNumBloks } from '@/utilities/getNumBloks';
+import { type MarginType } from '@/utilities/datasource';
 
 export type SbRowOneColumnProps = {
   blok: SbBlokData & {
-    columnContent: SbBlokData[];
+    columnContent?: SbBlokData[];
+    rowWidth?: RowOneColumnWidthType;
+    align?: RowAlignType;
+    spacingBottom?: MarginType;
   };
 }
 
 export const SbRowOneColumn = ({ blok }: SbRowOneColumnProps) => {
-  const { columnContent } = blok;
+  const {
+    columnContent,
+    rowWidth,
+    align,
+    spacingBottom,
+  } = blok;
 
   if (!getNumBloks(columnContent)) return null;
 
   return (
-    <RowOneColumn {...storyblokEditable(blok)}>
+    <RowOneColumn rowWidth={rowWidth} align={align} mb={spacingBottom} {...storyblokEditable(blok)}>
       <CreateBloks blokSection={columnContent} />
     </RowOneColumn>
   );

--- a/components/Storyblok/SbRowTwoColumns.tsx
+++ b/components/Storyblok/SbRowTwoColumns.tsx
@@ -1,7 +1,7 @@
 import { storyblokEditable, type SbBlokData } from '@storyblok/react/rsc';
 import { CreateBloks } from '@/components/CreateBloks';
 import {
-  RowTwoColumns, type RowAlignType, type RowWidthType, type WidthRatioType,
+  RowTwoColumns, type RowAlignType, type RowTwoColumnWidthType, type WidthRatioType,
 } from '@/components/Row';
 import { type MarginType } from '@/utilities/datasource';
 import { getNumBloks } from '@/utilities/getNumBloks';
@@ -10,7 +10,7 @@ export type SbRowTwoColumnProps = {
   blok: SbBlokData & {
     columnOneContent: SbBlokData[];
     columnTwoContent: SbBlokData[];
-    rowWidth?: RowWidthType;
+    rowWidth?: RowTwoColumnWidthType;
     widthRatio?: WidthRatioType;
     oneColumnMd?: boolean;
     contentAlignment?: 'start' | 'center' | 'end' | 'stretch';

--- a/components/Storyblok/SbSection.tsx
+++ b/components/Storyblok/SbSection.tsx
@@ -1,25 +1,84 @@
 import { storyblokEditable, type SbBlokData } from '@storyblok/react/rsc';
-import { Container } from '@/components/Container';
+import { type StoryblokRichtext } from 'storyblok-rich-text-react-renderer';
 import { CreateBloks } from '@/components/CreateBloks';
-import { type PaddingType } from '@/utilities/datasource';
+import { RichText } from '@/components/RichText';
+import { Section, type SectionContentWidthType, type TitleStyleType } from '@/components/Section';
+import { type HeadingType } from '@/components/Typography';
+import {
+  modTypeSizes, type PaddingType, type ModTypeSizeTypes, type LightPageBgColorType,
+} from '@/utilities/datasource';
+import { hasRichText } from '@/utilities/hasRichText';
 
-// TODO: This is a placeholder
-export type SbSectionProps = {
+type SbSectionProps = {
   blok: SbBlokData & {
+    hideSection?: boolean;
+    id?: string;
+    // Header
     title?: string;
+    intro?: StoryblokRichtext;
+    srOnlyHeader?: boolean;
+    disableWrapping?: boolean;
+    titleStyle?: TitleStyleType[];
+    tabColor?: string;
+    titleSize?: ModTypeSizeTypes;
+    headingLevel?: HeadingType;
+    // Campaign page only header options
+    isCenterAlign?: boolean; // Center align the header
+    isSansSemibold?: boolean; // Use sans-serif semibold Title
+    // Content
     content: SbBlokData[];
+    contentWidth?: string;
+    backgroundColor?: LightPageBgColorType;
     spacingTop?: PaddingType;
     spacingBottom?: PaddingType;
   };
 }
 
-export const SbSection = (props: SbSectionProps) => {
+export const SbSection = ({ blok }: SbSectionProps) => {
+  const {
+    hideSection,
+    id,
+    title,
+    intro,
+    srOnlyHeader,
+    disableWrapping,
+    titleStyle,
+    tabColor,
+    titleSize,
+    headingLevel,
+    isCenterAlign,
+    isSansSemibold,
+    content,
+    contentWidth,
+    backgroundColor,
+    spacingTop,
+    spacingBottom,
+  } = blok;
+
+  if (hideSection) return null;
+
+  const Intro = hasRichText(intro) ? <RichText baseFontSize="base23" wysiwyg={intro} /> : null;
+
   return (
-    <Container pt={props.blok.spacingTop} pb={props.blok.spacingBottom} {...storyblokEditable(props.blok)}>
-      {props.blok.title && (
-        <h2>{props.blok.title}</h2>
-      )}
-      <CreateBloks blokSection={props.blok.content} />
-    </Container>
+    <Section
+      {...storyblokEditable(blok)}
+      id={id}
+      title={title}
+      intro={Intro}
+      srOnlyHeader={srOnlyHeader}
+      isEdgeToEdgeHeader={disableWrapping}
+      titleStyle={titleStyle}
+      tabColor={tabColor}
+      titleSize={modTypeSizes[titleSize || 'su-mod-type-4']}
+      headingLevel={headingLevel}
+      isCenterAlignHeader={isCenterAlign}
+      isSansSemiboldTitle={isSansSemibold}
+      contentWidth={contentWidth as SectionContentWidthType}
+      bgColor={backgroundColor}
+      pt={spacingTop}
+      pb={spacingBottom}
+    >
+      <CreateBloks blokSection={content} />
+    </Section>
   );
 };

--- a/components/Storyblok/SbSection.tsx
+++ b/components/Storyblok/SbSection.tsx
@@ -5,7 +5,11 @@ import { RichText } from '@/components/RichText';
 import { Section, type SectionContentWidthType, type TitleStyleType } from '@/components/Section';
 import { type HeadingType } from '@/components/Typography';
 import {
-  modTypeSizes, type PaddingType, type ModTypeSizeTypes, type LightPageBgColorType, type DarkBeforeColorType,
+  modTypeSizes,
+  type PaddingType,
+  type ModTypeSizeTypes,
+  type LightPageBgColorType,
+  type DarkBeforeColorType,
 } from '@/utilities/datasource';
 import { hasRichText } from '@/utilities/hasRichText';
 
@@ -57,7 +61,7 @@ export const SbSection = ({ blok }: SbSectionProps) => {
 
   if (hideSection) return null;
 
-  const Intro = hasRichText(intro) ? <RichText baseFontSize="base23" wysiwyg={intro} textAlign={isCenterAlign ? 'center' : 'left'} /> : null;
+  const Intro = hasRichText(intro) ? <RichText wysiwyg={intro} baseFontSize="intro" textAlign={isCenterAlign ? 'center' : 'left'} /> : null;
 
   return (
     <Section
@@ -70,7 +74,7 @@ export const SbSection = ({ blok }: SbSectionProps) => {
       titleStyle={titleStyle}
       tabColor={tabColor}
       titleSize={modTypeSizes[titleSize || 'su-mod-type-4']}
-      headingLevel={headingLevel}
+      headingLevel={headingLevel || 'h2'}
       isCenterAlignHeader={isCenterAlign}
       isSansSemiboldTitle={isSansSemibold}
       contentWidth={contentWidth as SectionContentWidthType}

--- a/components/Storyblok/SbSection.tsx
+++ b/components/Storyblok/SbSection.tsx
@@ -5,7 +5,7 @@ import { RichText } from '@/components/RichText';
 import { Section, type SectionContentWidthType, type TitleStyleType } from '@/components/Section';
 import { type HeadingType } from '@/components/Typography';
 import {
-  modTypeSizes, type PaddingType, type ModTypeSizeTypes, type LightPageBgColorType,
+  modTypeSizes, type PaddingType, type ModTypeSizeTypes, type LightPageBgColorType, type DarkBeforeColorType,
 } from '@/utilities/datasource';
 import { hasRichText } from '@/utilities/hasRichText';
 
@@ -19,7 +19,7 @@ type SbSectionProps = {
     srOnlyHeader?: boolean;
     disableWrapping?: boolean;
     titleStyle?: TitleStyleType[];
-    tabColor?: string;
+    tabColor?: DarkBeforeColorType;
     titleSize?: ModTypeSizeTypes;
     headingLevel?: HeadingType;
     // Campaign page only header options
@@ -57,7 +57,7 @@ export const SbSection = ({ blok }: SbSectionProps) => {
 
   if (hideSection) return null;
 
-  const Intro = hasRichText(intro) ? <RichText baseFontSize="base23" wysiwyg={intro} /> : null;
+  const Intro = hasRichText(intro) ? <RichText baseFontSize="base23" wysiwyg={intro} textAlign={isCenterAlign ? 'center' : 'left'} /> : null;
 
   return (
     <Section

--- a/components/Storyblok/SbSingleColumnContent.tsx
+++ b/components/Storyblok/SbSingleColumnContent.tsx
@@ -7,7 +7,7 @@ import { type PaddingType } from '@/utilities/datasource';
 import { hasRichText } from '@/utilities/hasRichText';
 
 const contentWidths = {
-  'fit-container': 'su-w-full',
+  'fit-container': 'w-full',
   'flex-lg-8-of-12': 'lg:basis-8/12',
   'flex-md-10-of-12 flex-lg-8-of-12 flex-2xl-7-of-12': 'md:basis-10/12 lg:basis-8/12 2xl:basis-7/12',
 };
@@ -42,7 +42,7 @@ export const SbSingleColumnContent = (props: SbSingleColumnContentProps) => {
       <div
         className={cnb(
           'ood-single-column-content__wrapper',
-          props.blok.contentWidth === 'fit-container' ? 'ml-none' : 'mx-auto',
+          !props.blok.contentWidth || props.blok.contentWidth === 'fit-container' ? 'ml-none' : 'mx-auto',
           contentWidths[props.blok.contentWidth],
         )}
       >

--- a/components/Storyblok/SbSingleColumnContent.tsx
+++ b/components/Storyblok/SbSingleColumnContent.tsx
@@ -41,7 +41,6 @@ export const SbSingleColumnContent = (props: SbSingleColumnContentProps) => {
     >
       <div
         className={cnb(
-          'ood-single-column-content__wrapper',
           !props.blok.contentWidth || props.blok.contentWidth === 'fit-container' ? 'ml-none' : 'mx-auto',
           contentWidths[props.blok.contentWidth],
         )}

--- a/components/Typography/typography.styles.ts
+++ b/components/Typography/typography.styles.ts
@@ -72,13 +72,13 @@ export const textColors = {
 export const textVariants = {
   none: '', // Use default base/inherited style
   /**
-   * Decanter typography styles
+   * Decanter and custom typography styles
    */
   big: 'big-paragraph',
   subheading: 'subheading',
   caption: 'caption',
   card: 'card-paragraph',
-  intro: 'intro-text',
+  intro: 'text-20 md:text-25 lg:text-29',
   'base23': 'basefont-23',
 };
 

--- a/tailwind/plugins/base/base.ts
+++ b/tailwind/plugins/base/base.ts
@@ -27,6 +27,7 @@ export const base = ({ addBase, config }: { addBase: Function, config: Function 
       },
     },
     p: {
+      lineHeight: '1.4',
       '&:empty': {
         display: 'none',
       },

--- a/utilities/datasource.ts
+++ b/utilities/datasource.ts
@@ -30,6 +30,31 @@ export const darkBgColors = {
 };
 export type DarkBgColorType = keyof typeof darkBgColors;
 
+// For pseudo elements like tabs above headings
+export const darkBeforeColors = {
+  'bay-dark': 'before:bg-bay-dark',
+  'palo-alto': 'before:bg-palo-alto',
+  'palo-alto-dark': 'before:bg-palo-alto-dark',
+  'palo-verde-dark': 'before:bg-palo-verde-dark',
+  'lagunita': 'before:bg-lagunita',
+  'lagunita-dark': 'before:bg-lagunita-dark',
+  'sky-dark': 'before:bg-sky-dark',
+  'cardinal-red': 'before:bg-cardinal-red',
+  'digital-red': 'before:bg-digital-red',
+  'black': 'before:bg-black',
+  'fog-light': 'before:bg-fog-light',
+  'cardinal-dark-to-spirited-dark': 'before:bg-gradient-to-tr before:from-cardinal-dark before:to-spirited-dark',
+  'plum-to-digital-red': 'before:bg-gradient-to-tr before:from-plum before:to-digital-red',
+  'plum-to-spirited-dark': 'before:bg-gradient-to-tr before:from-plum before:to-spirited-dark',
+  'palo-alto-dark-to-palo-verde-dark': 'before:bg-gradient-to-tr before:from-palo-alto-dark before:to-palo-verde-dark',
+  'sky-dark-to-olive-dark': 'before:bg-gradient-to-tr before:from-sky-dark before:to-olive-dark',
+  'sky-dark-to-bay-dark': 'before:bg-gradient-to-tr before:from-sky-dark before:to-bay-dark',
+  'palo-verde': 'before:bg-palo-verde',
+  'plum': 'before:bg-plum',
+  'brick': 'before:bg-brick',
+};
+export type DarkBeforeColorType = keyof typeof darkBeforeColors;
+
 export const cardBgColors = {
   'white': 'bg-white',
   'bay-dark': 'bg-bay-dark',

--- a/utilities/datasource.ts
+++ b/utilities/datasource.ts
@@ -155,10 +155,10 @@ export const marginVerticals = {
  * Add more as needed
  */
 export const modTypeSizes: Record<string, FontSizeType> = {
-  'su-mod-type-3': 'f3',
-  'su-mod-type-4': 'f4',
-  'su-mod-type-5': 'f5',
-  'su-mod-type-6': 'f6',
+  'su-mod-type-3': 3,
+  'su-mod-type-4': 4,
+  'su-mod-type-5': 5,
+  'su-mod-type-6': 6,
 };
 export type ModTypeSizeTypes = keyof typeof modTypeSizes;
 

--- a/utilities/wysiwygClasses.ts
+++ b/utilities/wysiwygClasses.ts
@@ -12,6 +12,7 @@ export const wysiwygClasses = {
   'su-semibold': 'font-semibold',
   'su-bold': 'font-bold',
   'su-italic': 'italic',
+  'intro-text': 'text-20 md:text-25 lg:text-29',
   'callout': 'leading-display font-sans type-2 font-semibold',
   'splash-text': 'leading-display font-serif type-3 font-bold',
   // CTA styles


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- `Section` component
- Add options for `RowOneColumn` component 🤦🏼‍♀️ 
- Remove custom inline text color that gets in through copy and pasting text in WYSIWYG
- Misc fixups (for backward compatibility and other things)

# Review By (Date)
- Retro

# Criticality
- 5

# Review Tasks

## Setup tasks and/or behavior to test

NOTE: there will be some differences because previously when a centered container is nested inside another one, it still adds padding in the nested one, making it narrower than the outer centered container. Due to another developer's request, at one point in Decanter 7, we got rid of the padding of the nested inner centered container. Also the old flex width classes (eg, flex-lg-10-of-12) have slightly smaller width compared to how I TW-ize them (eg, to lg:w-10/12 or lg:basis-10/12 because the old one subtracts the grid gaps' widths).

Also, a lot of things on the current Giving don't have proper check for e.g., whether rich text exists, so some random margin can be added even when the wrapper shouldn't be rendered in the first place 😂 . Because of that, you'll see that in some places, it looks like there might be spacing missing in this PR preview. However, I think I'd rather address that in Storyblok (not in code) later. Trying to reduce weird logic just to make things visually exactly the same.

1. Go to https://deploy-preview-513--adapt-giving.netlify.app/the-stanford-fund/volunteer
Look at the main content area (to the right of the sidebar). Check that the spacing and width of cards (should take up full width of the content container) are same as on live:
https://giving.stanford.edu/the-stanford-fund/volunteer/

2. Go to https://deploy-preview-513--adapt-giving.netlify.app/how-to-make-a-gift
Compare with live:
https://giving.stanford.edu/how-to-make-a-gift/

4. Check out a few pages with Sections (can't compare to live because the content has been updated)
https://deploy-preview-513--adapt-giving.netlify.app/the-stanford-fund/leadership
https://deploy-preview-513--adapt-giving.netlify.app/

5. Go to https://deploy-preview-513--adapt-giving.netlify.app/about/careers
and check that this block of text in the WYSIWYG doesn't have inline text color that get pasted

![Screenshot 2025-06-28 at 12 14 22 PM](https://github.com/user-attachments/assets/9c6871bb-31dc-4a72-9871-449905ca4eb8)

compared to an older PR where this block had the pasted styles
https://deploy-preview-510--adapt-giving.netlify.app/about/careers
![Screenshot 2025-06-28 at 12 14 13 PM](https://github.com/user-attachments/assets/6b7de282-b969-4e3d-a29b-4c9aff6d6c31)


# Associated Issues and/or People
- DS-1468