### PR TITLE
DS-1749 | @ericbakenhus | Prevent _uid from appearing on CtaLink

### DIFF
--- a/components/Cta/CtaLink.tsx
+++ b/components/Cta/CtaLink.tsx
@@ -38,11 +38,11 @@ export const CtaLink = React.forwardRef<HTMLAnchorElement, CtaLinkProps>(
     } = sbLink || {};
 
     /**
-     * Filter out fieldtype and keep only props with non empty values from sbLinkProps.
+     * Filter out fieldtype and _uid and keep only props with non empty values from sbLinkProps.
      * These include additional attributes such as rel, title and custom attributes that the user can pass in.
      */
     const sbLinkPropsToKeep = Object.fromEntries(
-      Object.entries(sbLinkProps).filter(([key, value]) => key !== 'fieldtype' && value !== '' && value !== null && value !== undefined),
+      Object.entries(sbLinkProps).filter(([key, value]) => key !== 'fieldtype' && key !== '_uid' && value !== '' && value !== null && value !== undefined),
     );
 
     // Check for internal links


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- Filter out `_uid` from the props sent to `CtaExternalLink` from `CtaLink`
    - Just keeping the HTML validator happy; doesn't actually affect anything

# Review By (Date)
- Whenever

# Criticality
- Low

# Review Tasks

## Setup tasks and/or behavior to test

1. Maybe just look at code?
2. You can also check out the `Institutional funders﻿` link in the local header to see the `_uid` attribute disappear

# Associated Issues and/or People
- DS-1749