### PR TITLE
Stretch image to fit card

### DIFF
--- a/components/OverhangCard/OverhangCard.styles.ts
+++ b/components/OverhangCard/OverhangCard.styles.ts
@@ -17,4 +17,4 @@ export const root = (
 
 export const imageWrapper = 'shrink-0 grow-0 overflow-hidden -mt-80';
 
-export const image = (hasLink: boolean) => hasLink && 'group-hocus-within:scale-105 will-change transition-transform';
+export const image = (hasLink: boolean) => hasLink && 'group-hocus-within:scale-105 will-change transition-transform *:w-full';


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- If overhang card (eg, story card) is rendered in a large container, stretch card image to fill card image container

# Review By (Date)
- Retro

# Criticality
- 5

# Review Tasks

## Setup tasks and/or behavior to test

1. Check out this branch or go to the netlify preview
2. Navigate to...
3. Verify...
