### PR TITLE
DS-2398 | EmbedScript update

### DIFF
--- a/components/EmbedScript.tsx
+++ b/components/EmbedScript.tsx
@@ -25,25 +25,45 @@ export const EmbedScript = ({
 }: EmbedScriptProps) => {
   const containerRef = useRef<HTMLDivElement>(null);
 
-  const injectContent = useCallback(() => {
+  const injectContent = useCallback(async () => {
     if (!html || !containerRef.current) return;
+    const container = containerRef.current;
 
     try {
       // Create a 'tiny' document and parse the html string.
       // https://developer.mozilla.org/en-US/docs/Web/API/DocumentminiDom
       const miniDom = document.createRange().createContextualFragment(html);
 
-      // Force the scripts in the embed script field to load sync.
-      const scripts = miniDom.querySelectorAll('script');
-      for (const script of scripts) {
-        if (script.src && script.src.length > 0) {
-          script.async = false;
-          script.defer = false;
-        }
-      }
+      /**
+       * Pull scripts out before inserting. createContextualFragment runs them on insert,
+       * so an inline script that depends on an external src script
+       * (e.g. Double the Donation's ddplugin.js) would fire before that script
+       * finished loading and throw "<global> is not defined".
+       */
+      const scripts = Array.from(miniDom.querySelectorAll('script'));
+      scripts.forEach((s) => s.remove());
 
-      // Clear the container and append new content
-      containerRef.current.replaceChildren(miniDom);
+      // Inject the markup first, then run scripts in document order, awaiting
+      // each external (src) script so later inline scripts see its globals.
+      container.replaceChildren(miniDom);
+
+      for (const old of scripts) {
+        const script = document.createElement('script');
+        for (const { name, value } of old.attributes) {
+          script.setAttribute(name, value);
+        }
+        script.textContent = old.textContent;
+
+        const loaded = script.src
+          ? new Promise((resolve, reject) => {
+              script.onload = resolve;
+              script.onerror = reject;
+            })
+          : Promise.resolve();
+
+        container.appendChild(script);
+        await loaded;
+      }
     } catch (error) {
       logError('EmbedScript failed to inject content', error);
     }

--- a/components/EmbedScript.tsx
+++ b/components/EmbedScript.tsx
@@ -76,6 +76,7 @@ export const EmbedScript = ({
     }
   }, [html]);
 
+  // Inject after the component mounts via useEffect, so embedded scripts never block page render
   useEffect(() => {
     const controller = new AbortController();
     injectContent(controller.signal);

--- a/components/EmbedScript.tsx
+++ b/components/EmbedScript.tsx
@@ -25,7 +25,7 @@ export const EmbedScript = ({
 }: EmbedScriptProps) => {
   const containerRef = useRef<HTMLDivElement>(null);
 
-  const injectContent = useCallback(async () => {
+  const injectContent = useCallback(async (signal: AbortSignal) => {
     if (!html || !containerRef.current) return;
     const container = containerRef.current;
 
@@ -43,11 +43,17 @@ export const EmbedScript = ({
       const scripts = Array.from(miniDom.querySelectorAll('script'));
       scripts.forEach((s) => s.remove());
 
-      // Inject the markup first, then run scripts in document order, awaiting
-      // each external (src) script so later inline scripts see its globals.
+      /**
+       * Inject the markup first, then run scripts in document order,
+       * awaiting each external (src) script so later inline scripts see its globals.
+       * Bail if a newer render already started — prevents the visual editor's
+       * rapid re-renders from running two injections against the same container
+       */
+      if (signal.aborted) return;
       container.replaceChildren(miniDom);
 
       for (const old of scripts) {
+        if (signal.aborted) return;
         const script = document.createElement('script');
         for (const { name, value } of old.attributes) {
           script.setAttribute(name, value);
@@ -63,6 +69,7 @@ export const EmbedScript = ({
 
         container.appendChild(script);
         await loaded;
+        if (signal.aborted) return;
       }
     } catch (error) {
       logError('EmbedScript failed to inject content', error);
@@ -70,7 +77,9 @@ export const EmbedScript = ({
   }, [html]);
 
   useEffect(() => {
-    injectContent();
+    const controller = new AbortController();
+    injectContent(controller.signal);
+    return () => controller.abort();
   }, [injectContent]);
 
   return (


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- Make EmbedScript more robust, allowing the Double the Donation embed to work (currently it doesn't - widget shows up when you paste the code in the editor but disappears once you save or publish)

# Review By (Date)
- Soon

# Criticality
- 6

# Review Tasks

## Setup tasks and/or behavior to test

1. Go to https://deploy-preview-729--adapt-giving.netlify.app/how-to-make-a-gift/matching-gifts
2. Check that the Double the Donation widget showed up
3. Try entering a company name eg, Google and test that it works
4. Go to https://deploy-preview-729--adapt-giving.netlify.app/planned-giving/calculator
5. Check that the previously embedded calculator still renders and works
6. Also life income tables (embedded HTML) - check that they render
https://deploy-preview-729--adapt-giving.netlify.app/life-income/compare

# Associated Issues and/or People
- JIRA ticket(s) - DS-2398